### PR TITLE
feat: add performance assertions to complete issue #36

### DIFF
--- a/test/integration/best-practices.test.ts
+++ b/test/integration/best-practices.test.ts
@@ -253,6 +253,49 @@ describe('Best Practices Integration Tests', () => {
       // Cached call should be faster or equal (handles sub-millisecond timing)
       // If both are 0 (sub-millisecond), that's fine - both are fast
       expect(duration2).toBeLessThanOrEqual(Math.max(duration1, 1));
+      
+      // Cached call should complete in <300ms (performance requirement)
+      expect(duration2).toBeLessThan(300);
+    }, 60000);
+
+    it('completes cached analysis in <300ms', async () => {
+      // First call to populate cache
+      await toolHandler.executeTool('analyze_best_practices', {
+        topic: 'module_organization'
+      });
+
+      // Measure cached performance
+      const start = Date.now();
+      const result = await toolHandler.executeTool('analyze_best_practices', {
+        topic: 'module_organization'
+      });
+      const duration = Date.now() - start;
+
+      // Verify result is valid
+      expect(result).toBeDefined();
+      expect(result.topic).toBe('module_organization');
+      expect(result.confidence).toBeDefined();
+
+      // Performance requirement: <300ms for cached analysis
+      expect(duration).toBeLessThan(300);
+    }, 60000);
+
+    it('completes first-time analysis in reasonable time (<2s)', async () => {
+      // This test simulates MCP server restart with docs already cached on disk
+      // Using a topic not used in previous tests to avoid in-memory cache
+      const start = Date.now();
+      const result = await toolHandler.executeTool('analyze_best_practices', {
+        topic: 'ci_cd'
+      });
+      const duration = Date.now() - start;
+
+      // Verify result is valid
+      expect(result).toBeDefined();
+      expect(result.topic).toBe('ci_cd');
+      expect(result.recommendations).toBeDefined();
+
+      // Even first-time should be reasonable (docs cached on disk)
+      expect(duration).toBeLessThan(2000);
     }, 60000);
 
     it('caches results separately by experience level', async () => {


### PR DESCRIPTION
## Description

This PR completes issue #36 by adding explicit performance assertions to the integration tests for the best practices tool.

## Changes

Added 3 performance-related tests to `test/integration/best-practices.test.ts`:

1. **Updated existing caching test** - Added `expect(duration2).toBeLessThan(300)` assertion to verify cached responses meet the <300ms requirement
2. **New: Cached analysis performance** - Dedicated test that verifies cached analysis completes in <300ms
3. **New: First-time analysis performance** - Test that verifies cold-start (MCP server restart scenario) completes in <2s with docs cached on disk

## Test Results

✅ All 48 integration tests passing (27 in best-practices.test.ts + 21 in best-practices-tool.test.ts)

Performance thresholds:
- **Cached analysis**: <300ms ✅
- **Cold start**: <2000ms ✅

## Context

Issue #36 requested integration tests for the best practices tool. The comprehensive test suite (48 tests) already existed from issues #31 and #34, covering:

- ✅ All 7 topics (module_organization, state_management, dependencies, ci_cd, security, performance, testing)
- ✅ MCP protocol compliance
- ✅ Error handling and fuzzy matching
- ✅ Experience level filtering
- ✅ Recommendation quality validation
- ✅ Real documentation extraction

The only gap was explicit performance assertions, which this PR addresses.

## Testing

```bash
npm test -- test/integration/best-practices.test.ts test/integration/best-practices-tool.test.ts
```

All tests pass locally. CI will verify performance thresholds are realistic for CI environment.

## Relates to

Closes #36