### PR TITLE
feat: implement Mustache conditional rendering in template engine

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,8 +10,10 @@
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.20.1",
+        "@types/mustache": "^4.2.6",
         "cheerio": "^1.0.0-rc.12",
         "lru-cache": "^11.2.2",
+        "mustache": "^4.2.0",
         "node-fetch": "^3.3.2",
         "ts-node": "^10.9.0",
         "typescript": "^5.0.0"
@@ -1266,6 +1268,12 @@
       "dependencies": {
         "lru-cache": "*"
       }
+    },
+    "node_modules/@types/mustache": {
+      "version": "4.2.6",
+      "resolved": "https://registry.npmjs.org/@types/mustache/-/mustache-4.2.6.tgz",
+      "integrity": "sha512-t+8/QWTAhOFlrF1IVZqKnMRJi84EgkIK5Kh0p2JV4OLywUvCwJPFxbJAl7XAow7DVIHsF+xW9f1MVzg0L6Szjw==",
+      "license": "MIT"
     },
     "node_modules/@types/node": {
       "version": "24.9.1",
@@ -3472,6 +3480,15 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "license": "MIT"
+    },
+    "node_modules/mustache": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/mustache/-/mustache-4.2.0.tgz",
+      "integrity": "sha512-71ippSywq5Yb7/tVYyGbkBggbU8H3u5Rz56fH60jGFgr8uHwxs+aSKeqmluIVzM0m0kB7xQjKS6qPfd0b2ZoqQ==",
+      "license": "MIT",
+      "bin": {
+        "mustache": "bin/mustache"
+      }
     },
     "node_modules/nanoid": {
       "version": "3.3.11",

--- a/package.json
+++ b/package.json
@@ -29,8 +29,10 @@
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.20.1",
+    "@types/mustache": "^4.2.6",
     "cheerio": "^1.0.0-rc.12",
     "lru-cache": "^11.2.2",
+    "mustache": "^4.2.0",
     "node-fetch": "^3.3.2",
     "ts-node": "^10.9.0",
     "typescript": "^5.0.0"

--- a/src/terragrunt/generator.ts
+++ b/src/terragrunt/generator.ts
@@ -3,6 +3,7 @@ import { validateHCL } from './hcl-validator.js';
 import { ConfigTemplateLibrary, UseCase } from './library.js';
 import { ConfigTemplate, ConfigVariable } from '../types/templates.js';
 import { GenerateConfigParams, GeneratedConfig, VariableValidationResult } from '../types/generator.js';
+import Mustache from 'mustache';
 
 /**
  * TerragruntConfigGenerator generates complete terragrunt.hcl configurations
@@ -98,21 +99,57 @@ export class TerragruntConfigGenerator {
   }
 
   /**
-   * Build configuration from template with variable substitution
+   * Build configuration from template with variable substitution.
+   * 
+   * Uses two-phase rendering:
+   * 1. Phase 1: Process Mustache conditionals ({{#var}}...{{/var}}, {{^var}}...{{/var}})
+   * 2. Phase 2: Type-aware value substitution for remaining {{variable}} placeholders
+   * 
+   * This approach allows optional fields in templates while preserving
+   * HCL type-aware formatting (strings quoted, booleans/numbers unquoted).
    */
   private async buildFromTemplate(template: ConfigTemplate, values: Record<string, string | number | boolean>): Promise<string> {
-    let config = template.templateHcl;
-
     // Find variable metadata for type-aware substitution
     const variableMap = new Map<string, ConfigVariable>();
     for (const variable of template.variables) {
       variableMap.set(variable.name, variable);
     }
 
-    // Replace all {{variable}} placeholders
+    // ============================================================
+    // Phase 1: Process Mustache conditionals
+    // ============================================================
+    // Create a context object for Mustache where:
+    // - Variables with values are truthy (their presence enables conditional blocks)
+    // - Variables without values are falsy (conditional blocks are removed)
+    // 
+    // We use placeholder markers instead of actual values so that
+    // Phase 2 can do type-aware substitution.
+    const mustacheContext: Record<string, string | boolean> = {};
+    
+    for (const variable of template.variables) {
+      const value = values[variable.name];
+      if (value !== undefined && value !== null && value !== '') {
+        // Variable has a value - make it truthy for conditionals
+        // Use a unique placeholder that won't conflict with other content
+        mustacheContext[variable.name] = `__PLACEHOLDER_${variable.name}__`;
+      }
+      // If variable has no value, it won't be in context (falsy for Mustache)
+    }
+
+    // Disable Mustache's HTML escaping since we're generating HCL, not HTML
+    Mustache.escape = (text: string) => text;
+    
+    // Render conditionals - this removes {{#var}}...{{/var}} blocks for missing variables
+    // and keeps them (with placeholders) for present variables
+    let config = Mustache.render(template.templateHcl, mustacheContext);
+
+    // ============================================================
+    // Phase 2: Type-aware value substitution
+    // ============================================================
+    // Now replace all placeholders with properly formatted values
     for (const [name, value] of Object.entries(values)) {
       const variable = variableMap.get(name);
-      const placeholder = `{{${name}}}`;
+      const placeholder = `__PLACEHOLDER_${name}__`;
 
       // Type-aware substitution
       let substitutedValue: string;
@@ -129,12 +166,39 @@ export class TerragruntConfigGenerator {
         const escapedValue = stringValue.replace(/\\/g, '\\\\').replace(/"/g, '\\"');
         
         // Check if placeholder is already within quotes in template
-        const quotedPattern = new RegExp(`"${placeholder.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}"`, 'g');
+        const quotedPattern = new RegExp(`"${placeholder}"`, 'g');
         if (config.match(quotedPattern)) {
           // Already quoted in template, substitute without adding quotes
           substitutedValue = escapedValue;
         } else {
           // Not quoted, add quotes
+          substitutedValue = `"${escapedValue}"`;
+        }
+      }
+
+      config = config.replace(new RegExp(placeholder, 'g'), substitutedValue);
+    }
+
+    // Also handle any remaining {{variable}} placeholders that weren't in conditionals
+    // (backward compatibility with simple templates)
+    for (const [name, value] of Object.entries(values)) {
+      const variable = variableMap.get(name);
+      const placeholder = `{{${name}}}`;
+
+      // Type-aware substitution
+      let substitutedValue: string;
+      if (variable?.type === 'boolean') {
+        substitutedValue = String(value);
+      } else if (variable?.type === 'number') {
+        substitutedValue = String(value);
+      } else {
+        const stringValue = String(value);
+        const escapedValue = stringValue.replace(/\\/g, '\\\\').replace(/"/g, '\\"');
+        
+        const quotedPattern = new RegExp(`"${placeholder.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}"`, 'g');
+        if (config.match(quotedPattern)) {
+          substitutedValue = escapedValue;
+        } else {
           substitutedValue = `"${escapedValue}"`;
         }
       }

--- a/test/unit/config-generator.test.ts
+++ b/test/unit/config-generator.test.ts
@@ -574,4 +574,130 @@ describe('TerragruntConfigGenerator', () => {
       expect(result.config).toContain('dependency');
     });
   });
+
+  describe('conditional rendering (Mustache)', () => {
+    it('should include conditional blocks when variable is provided', async () => {
+      const result = await generator.generateConfig({
+        useCase: 'remote_state',
+        backend: 'gcp',
+        options: {
+          bucket: 'my-gcs-bucket',
+          prefix: 'terraform/state',
+          project: 'my-gcp-project',
+        },
+      });
+
+      // Project should be included since it was provided
+      expect(result.config).toContain('project');
+      expect(result.config).toContain('my-gcp-project');
+    });
+
+    it('should exclude conditional blocks when variable is not provided', async () => {
+      const result = await generator.generateConfig({
+        useCase: 'remote_state',
+        backend: 'gcp',
+        options: {
+          bucket: 'my-gcs-bucket',
+          prefix: 'terraform/state',
+          // project and credentials are optional
+        },
+      });
+
+      // Required fields should be present
+      expect(result.config).toContain('bucket');
+      expect(result.config).toContain('my-gcs-bucket');
+      expect(result.config).toContain('prefix');
+      
+      // Optional fields should NOT have their Mustache conditional syntax
+      expect(result.config).not.toContain('{{#project}}');
+      expect(result.config).not.toContain('{{/project}}');
+      expect(result.config).not.toContain('{{#credentials}}');
+      expect(result.config).not.toContain('{{/credentials}}');
+    });
+
+    it('should handle GCP backend with all optional fields', async () => {
+      const result = await generator.generateConfig({
+        useCase: 'remote_state',
+        backend: 'gcp',
+        options: {
+          bucket: 'my-gcs-bucket',
+          prefix: 'terraform/state',
+          project: 'my-gcp-project',
+          credentials: '/path/to/credentials.json',
+        },
+      });
+
+      expect(result.config).toContain('bucket');
+      expect(result.config).toContain('prefix');
+      expect(result.config).toContain('project');
+      expect(result.config).toContain('credentials');
+      expect(result.config).toContain('my-gcp-project');
+      expect(result.config).toContain('/path/to/credentials.json');
+    });
+
+    it('should handle GCP backend with only required fields', async () => {
+      const result = await generator.generateConfig({
+        useCase: 'remote_state',
+        backend: 'gcp',
+        options: {
+          bucket: 'my-gcs-bucket',
+          prefix: 'terraform/state',
+        },
+      });
+
+      expect(result.config).toContain('bucket');
+      expect(result.config).toContain('prefix');
+      // Should not contain project or credentials values when not provided
+      expect(result.config).not.toContain('project');
+      expect(result.config).not.toContain('credentials');
+    });
+
+    it('should not leave Mustache syntax in output', async () => {
+      const result = await generator.generateConfig({
+        useCase: 'remote_state',
+        backend: 'gcp',
+        options: {
+          bucket: 'test-bucket',
+          prefix: 'state/',
+        },
+      });
+
+      // No Mustache syntax should remain in output
+      expect(result.config).not.toMatch(/\{\{[#^\/]?\w+\}\}/);
+    });
+
+    it('should preserve non-conditional variable substitution', async () => {
+      const result = await generator.generateConfig({
+        useCase: 'remote_state',
+        backend: 's3',
+        options: {
+          bucket: 'my-bucket',
+          key: 'terraform.tfstate',
+          region: 'us-east-1',
+          dynamodb_table: 'locks',
+        },
+      });
+
+      // Standard substitution should still work
+      expect(result.config).toContain('bucket         = "my-bucket"');
+      expect(result.config).toContain('region         = "us-east-1"');
+      // No Mustache syntax should remain
+      expect(result.config).not.toMatch(/\{\{[#^\/]?\w+\}\}/);
+    });
+
+    it('should handle empty string values as falsy for conditionals', async () => {
+      const result = await generator.generateConfig({
+        useCase: 'remote_state',
+        backend: 'gcp',
+        options: {
+          bucket: 'my-gcs-bucket',
+          prefix: 'terraform/state',
+          project: '', // Empty string should be treated as not provided
+        },
+      });
+
+      // Empty string project should not appear in output
+      expect(result.config).not.toContain('project');
+    });
+  });
 });


### PR DESCRIPTION
## Summary
Implements two-phase template rendering to support Mustache conditionals in HCL templates.

## Problem
Templates like GCP backend have optional fields (project, credentials) that should only appear in output when the variable is provided. The previous implementation didn't support Mustache conditional syntax (`{{#var}}...{{/var}}`), leaving these sections as literal text in the output.

## Solution
Two-phase rendering in `buildFromTemplate()`:

1. **Phase 1: Mustache.render()** - Processes conditionals
   - Variables are converted to booleans (truthy if defined, non-null, non-empty)
   - Conditional blocks (`{{#var}}content{{/var}}`) are included/excluded based on truthiness

2. **Phase 2: Type-aware HCL substitution** - Existing logic preserved
   - Strings get quoted (`"value"`)
   - Booleans and numbers remain unquoted

## Changes
- Add `mustache` and `@types/mustache` dependencies
- Refactor `buildFromTemplate()` in generator.ts for two-phase rendering
- Add 7 unit tests for conditional rendering behavior

## Test Coverage (7 new tests)
- ✅ Include conditional blocks when variable provided
- ✅ Exclude conditional blocks when variable not provided
- ✅ Handle GCP backend with all optional fields
- ✅ Handle GCP backend with only required fields
- ✅ Ensure no Mustache syntax leaks to output
- ✅ Preserve non-conditional variable substitution
- ✅ Treat empty string values as falsy for conditionals

## Example
```hcl
# GCP template with conditionals:
{{#project}}
    project     = "{{project}}"
{{/project}}
{{#credentials}}
    credentials = "{{credentials}}"
{{/credentials}}

# Output when only bucket/prefix provided:
remote_state {
  backend = "gcs"
  config = {
    bucket = "my-bucket"
    prefix = "state/"
  }
}
```

## Impact
This is a **critical path blocker** for Epic #87 (Enhanced Backend Template Support). Unblocks:
- Issue #89 (S3 advanced options)
- Issue #90 (Azure advanced options)
- Issue #91 (GCP advanced options)

Closes #88