### PR TITLE
feat(tools): add block comparison and pattern guidance tools

### DIFF
--- a/docs/Available-Tools.md
+++ b/docs/Available-Tools.md
@@ -1,6 +1,6 @@
 # Available Tools
 
-The Terragrunt MCP Server provides **13 specialized tools** for accessing and searching Terragrunt documentation, generating configurations, analyzing best practices, diagnosing errors, and writing files. Each tool is designed for specific use cases to help you find the information you need quickly.
+The Terragrunt MCP Server provides **15 specialized tools** for accessing and searching Terragrunt documentation, generating configurations, analyzing best practices, diagnosing errors, comparing blocks, and writing files. Each tool is designed for specific use cases to help you find the information you need quickly.
 
 ## Tool Overview
 
@@ -19,6 +19,8 @@ The Terragrunt MCP Server provides **13 specialized tools** for accessing and se
 | `write_terragrunt_config` | Write configs to disk | Saving generated configurations |
 | `analyze_best_practices` | Analyze practices by topic | Learning best practices and patterns |
 | `diagnose_terragrunt_error` | Error diagnosis | Troubleshooting Terragrunt errors |
+| `compare_hcl_blocks` | Block comparison | Understanding differences between similar blocks |
+| `get_pattern_guidance` | Pattern guidance | Choosing between configuration patterns |
 
 ---
 
@@ -1083,6 +1085,172 @@ When `enrichWithDocs: true`, you get additional documentation-sourced solutions:
 
 **"Help me troubleshoot this Terragrunt error..."**
 → Use `diagnose_terragrunt_error` with `enrichWithDocs: true` for comprehensive solutions
+
+**"What's the difference between dependency and dependencies?"**
+→ Use `compare_hcl_blocks` to see a detailed comparison with use cases
+
+**"When should I use include vs multiple includes?"**
+→ Use `compare_hcl_blocks` for block-level differences or `get_pattern_guidance` for architectural patterns
+
+**"How should I manage dependencies between modules?"**
+→ Use `get_pattern_guidance` to see different approaches with pros/cons and examples
+
+---
+
+## 14. compare_hcl_blocks
+
+**Purpose**: Compare two similar HCL blocks and explain their differences, use cases, and when to use each. Supports natural language queries like "dependency vs dependencies" and uses fuzzy matching for typo tolerance.
+
+### Parameters — compare_hcl_blocks
+
+- **`block1`** (string, optional): First block name or comparison query (e.g., "dependency" or "dependency vs dependencies")
+- **`block2`** (string, optional): Second block name (optional if block1 contains both)
+- **`listComparisons`** (boolean, optional): List all available comparisons
+
+### Available Comparisons
+
+| Comparison | Summary |
+|------------|---------|
+| `dependency` vs `dependencies` | Single dependency with output access vs. bulk ordering without outputs |
+| `include` vs `multiple includes` | Single parent inheritance vs. composable configuration from multiple sources |
+| `inputs` vs `locals` | Values passed to Terraform vs. internal Terragrunt values |
+| `generate` vs `terraform.source` | Creating .tf files vs. specifying module source |
+| `before_hook` vs `after_hook` | Commands before Terraform vs. commands after |
+| `remote_state` vs `dependency` | Where to store state vs. how to read other module outputs |
+
+### Use Cases — compare_hcl_blocks
+
+- Understanding subtle differences between similar constructs
+- Deciding which block to use for your use case
+- Learning about common mistakes with each block
+- Getting syntax examples for both options
+
+### Example Prompts — compare_hcl_blocks
+
+```text
+"What's the difference between dependency and dependencies?"
+"Compare inputs vs locals in Terragrunt"
+"When should I use generate vs terraform.source?"
+"Explain before_hook versus after_hook"
+```
+
+### Example Response — compare_hcl_blocks
+
+```json
+{
+  "found": true,
+  "comparison": {
+    "id": "dependency-vs-dependencies",
+    "blocks": ["dependency", "dependencies"],
+    "summary": "dependency defines a single module dependency with output access; dependencies lists modules that must run first without output access.",
+    "block1": {
+      "name": "dependency",
+      "purpose": "Declare a dependency on another Terragrunt module and access its outputs",
+      "syntax": "dependency \"vpc\" {\n  config_path = \"../vpc\"\n  ...\n}",
+      "keyFeatures": [
+        "Access outputs from dependent module",
+        "Supports mock_outputs for planning",
+        "Each dependency block has a unique name"
+      ]
+    },
+    "block2": {
+      "name": "dependencies",
+      "purpose": "Declare execution order dependencies without needing output access",
+      "syntax": "dependencies {\n  paths = [\"../vpc\", \"../sg\"]\n}",
+      "keyFeatures": [
+        "Simple list of paths that must be applied first",
+        "No access to outputs from listed modules",
+        "Lightweight - no state file reading required"
+      ]
+    },
+    "keyDifferences": [
+      {
+        "aspect": "Output Access",
+        "block1": "Full access to dependent module outputs",
+        "block2": "No output access - ordering only"
+      }
+    ],
+    "whenToUse": {
+      "useBlock1When": ["You need to pass outputs from one module to another"],
+      "useBlock2When": ["You only need to ensure modules run in a specific order"]
+    },
+    "commonMistakes": [
+      "Using dependencies when you actually need output values"
+    ],
+    "relatedDocs": ["https://terragrunt.gruntwork.io/docs/..."]
+  }
+}
+```
+
+---
+
+## 15. get_pattern_guidance
+
+**Purpose**: Get guidance on choosing between Terragrunt configuration patterns for common scenarios. Returns decision criteria, pattern options with pros/cons, and code examples.
+
+### Parameters — get_pattern_guidance
+
+- **`scenario`** (string, optional): The scenario to get guidance for (e.g., "managing dependencies", "configuration inheritance")
+- **`listPatterns`** (boolean, optional): List all available pattern guidance topics
+
+### Available Pattern Topics
+
+| Scenario | Question Answered |
+|----------|-------------------|
+| Module Dependency Management | How should I manage dependencies between my Terragrunt modules? |
+| Configuration Inheritance | How should I structure configuration inheritance in my project? |
+| Backend State Management | How should I configure my Terraform backend in Terragrunt? |
+
+### Use Cases — get_pattern_guidance
+
+- Making architectural decisions about project structure
+- Choosing between different approaches for common problems
+- Understanding trade-offs between patterns
+- Getting working examples for your chosen pattern
+
+### Example Prompts — get_pattern_guidance
+
+```text
+"How should I manage dependencies between modules?"
+"What's the best way to handle configuration inheritance?"
+"How do I configure state management in Terragrunt?"
+"Help me choose a pattern for my multi-environment setup"
+```
+
+### Example Response — get_pattern_guidance
+
+```json
+{
+  "found": true,
+  "guidance": {
+    "id": "module-dependency-management",
+    "scenario": "Managing dependencies between Terraform modules",
+    "question": "How should I manage dependencies between my Terragrunt modules?",
+    "decisionCriteria": [
+      {
+        "criterion": "You need to pass output values from one module to another",
+        "recommendation": "Use dependency blocks",
+        "reason": "dependency blocks expose .outputs for accessing values like VPC IDs"
+      },
+      {
+        "criterion": "You only need modules to run in a specific order, no data passing",
+        "recommendation": "Use dependencies block",
+        "reason": "dependencies is lighter weight - no state reading, just ordering"
+      }
+    ],
+    "patterns": [
+      {
+        "name": "Explicit Output Dependencies",
+        "description": "Use named dependency blocks for each module whose outputs you need",
+        "example": "dependency \"vpc\" {\n  config_path = \"../vpc\"\n  mock_outputs = { vpc_id = \"mock\" }\n}",
+        "pros": ["Clear, explicit data flow", "Supports mock values"],
+        "cons": ["Reads state files (slower)", "Must maintain mock_outputs"]
+      }
+    ],
+    "relatedComparisons": ["dependency vs dependencies"]
+  }
+}
+```
 
 ---
 

--- a/src/handlers/tools.ts
+++ b/src/handlers/tools.ts
@@ -14,6 +14,7 @@ import { ErrorPatternMatcher } from '../terragrunt/error-patterns.js';
 import { CLICommandsManager } from '../terragrunt/cli-commands.js';
 import { HCLBlocksManager } from '../terragrunt/hcl-blocks.js';
 import { AdvancedExamplesManager } from '../terragrunt/advanced-examples.js';
+import { BlockComparisonManager } from '../terragrunt/comparisons.js';
 import type { HCLBlock } from '../types/hcl-blocks.js';
 import type { AdvancedExampleCategory } from '../types/advanced-examples.js';
 
@@ -32,6 +33,7 @@ export class ToolHandler {
     private cliCommandsManager: CLICommandsManager;
     private hclBlocksManager: HCLBlocksManager;
     private advancedExamplesManager: AdvancedExamplesManager;
+    private blockComparisonManager: BlockComparisonManager;
     private functionsLoaded: boolean = false;
     private templatesManager: TemplatesManager;
     private templateLibrary: ConfigTemplateLibrary;
@@ -47,6 +49,7 @@ export class ToolHandler {
         this.cliCommandsManager = new CLICommandsManager();
         this.hclBlocksManager = new HCLBlocksManager();
         this.advancedExamplesManager = new AdvancedExamplesManager();
+        this.blockComparisonManager = new BlockComparisonManager();
         
         // Initialize templates manager with builtin and filesystem loaders
         this.templatesManager = new TemplatesManager([
@@ -467,6 +470,48 @@ export class ToolHandler {
                     },
                     required: ['error_message']
                 }
+            },
+            {
+                name: 'compare_hcl_blocks',
+                description: 'Compare two similar HCL blocks and explain their differences, use cases, and when to use each. Supports natural language queries like "dependency vs dependencies" or separate block names. Uses fuzzy matching for typo tolerance.',
+                inputSchema: {
+                    type: 'object',
+                    properties: {
+                        block1: {
+                            type: 'string',
+                            description: 'First block name to compare (e.g., "dependency") or a comparison query (e.g., "dependency vs dependencies")'
+                        },
+                        block2: {
+                            type: 'string',
+                            description: 'Second block name to compare (optional if block1 contains both, e.g., "dependency vs dependencies")'
+                        },
+                        listComparisons: {
+                            type: 'boolean',
+                            description: 'If true, list all available block comparisons',
+                            default: false
+                        }
+                    },
+                    required: []
+                }
+            },
+            {
+                name: 'get_pattern_guidance',
+                description: 'Get guidance on choosing between Terragrunt configuration patterns for common scenarios like dependency management, configuration inheritance, and state management. Returns decision criteria, pattern options with pros/cons, and code examples.',
+                inputSchema: {
+                    type: 'object',
+                    properties: {
+                        scenario: {
+                            type: 'string',
+                            description: 'The scenario or pattern to get guidance for (e.g., "managing dependencies", "configuration inheritance", "backend state")'
+                        },
+                        listPatterns: {
+                            type: 'boolean',
+                            description: 'If true, list all available pattern guidance topics',
+                            default: false
+                        }
+                    },
+                    required: []
+                }
             }
         ];
     }
@@ -601,6 +646,19 @@ export class ToolHandler {
                         args.error_message,
                         args.context,
                         args.options
+                    );
+
+                case 'compare_hcl_blocks':
+                    return this.compareHclBlocks(
+                        args?.block1,
+                        args?.block2,
+                        args?.listComparisons ?? false
+                    );
+
+                case 'get_pattern_guidance':
+                    return this.getPatternGuidance(
+                        args?.scenario,
+                        args?.listPatterns ?? false
                     );
 
                 default:
@@ -1524,5 +1582,144 @@ export class ToolHandler {
                 error: error instanceof Error ? error.message : 'Failed to diagnose error'
             };
         }
+    }
+
+    /**
+     * Compare two HCL blocks and explain their differences
+     */
+    private compareHclBlocks(
+        block1?: string,
+        block2?: string,
+        listComparisons: boolean = false
+    ): any {
+        // List all available comparisons
+        if (listComparisons) {
+            const comparisons = this.blockComparisonManager.getAvailableComparisons();
+            const patterns = this.blockComparisonManager.getAvailablePatterns();
+            return {
+                availableComparisons: comparisons,
+                availablePatternTopics: patterns,
+                usage: 'Use block1 and block2 parameters to compare specific blocks, or use block1 with a query like "dependency vs dependencies"'
+            };
+        }
+
+        // Need at least one block to compare
+        if (!block1) {
+            const comparisons = this.blockComparisonManager.getAvailableComparisons();
+            return {
+                error: 'Please specify blocks to compare',
+                availableComparisons: comparisons,
+                examples: [
+                    'block1: "dependency vs dependencies"',
+                    'block1: "dependency", block2: "dependencies"',
+                    'block1: "include vs multiple includes"'
+                ]
+            };
+        }
+
+        const result = this.blockComparisonManager.compareBlocks(block1, block2);
+
+        if (!result.found) {
+            return {
+                found: false,
+                error: result.error,
+                suggestions: result.suggestions,
+                hint: 'Try using listComparisons: true to see all available comparisons'
+            };
+        }
+
+        const comparison = result.comparison!;
+
+        return {
+            found: true,
+            comparison: {
+                id: comparison.id,
+                blocks: comparison.blocks,
+                summary: comparison.summary,
+                block1: {
+                    name: comparison.block1Details.name,
+                    purpose: comparison.block1Details.purpose,
+                    syntax: comparison.block1Details.syntax,
+                    keyFeatures: comparison.block1Details.keyFeatures
+                },
+                block2: {
+                    name: comparison.block2Details.name,
+                    purpose: comparison.block2Details.purpose,
+                    syntax: comparison.block2Details.syntax,
+                    keyFeatures: comparison.block2Details.keyFeatures
+                },
+                keyDifferences: comparison.keyDifferences,
+                whenToUse: comparison.whenToUse,
+                commonMistakes: comparison.commonMistakes,
+                relatedDocs: comparison.relatedDocs
+            }
+        };
+    }
+
+    /**
+     * Get pattern guidance for a configuration scenario
+     */
+    private getPatternGuidance(
+        scenario?: string,
+        listPatterns: boolean = false
+    ): any {
+        // List all available patterns
+        if (listPatterns) {
+            const patterns = this.blockComparisonManager.getAvailablePatterns();
+            const comparisons = this.blockComparisonManager.getAvailableComparisons();
+            return {
+                availablePatternTopics: patterns,
+                relatedBlockComparisons: comparisons,
+                usage: 'Use scenario parameter to get guidance for a specific topic (e.g., "managing dependencies", "configuration inheritance")'
+            };
+        }
+
+        // Need a scenario to provide guidance
+        if (!scenario) {
+            const patterns = this.blockComparisonManager.getAvailablePatterns();
+            return {
+                error: 'Please specify a scenario to get guidance for',
+                availablePatternTopics: patterns,
+                examples: [
+                    'scenario: "managing dependencies"',
+                    'scenario: "configuration inheritance"',
+                    'scenario: "backend state"'
+                ]
+            };
+        }
+
+        const result = this.blockComparisonManager.getPatternGuidance(scenario);
+
+        if (!result.found) {
+            return {
+                found: false,
+                error: result.error,
+                suggestions: result.suggestions,
+                hint: 'Try using listPatterns: true to see all available pattern topics'
+            };
+        }
+
+        const guidance = result.guidance!;
+
+        return {
+            found: true,
+            guidance: {
+                id: guidance.id,
+                scenario: guidance.scenario,
+                question: guidance.question,
+                decisionCriteria: guidance.decisionCriteria,
+                patterns: guidance.patterns.map(p => ({
+                    name: p.name,
+                    description: p.description,
+                    example: p.example,
+                    pros: p.pros,
+                    cons: p.cons
+                })),
+                relatedComparisons: guidance.relatedComparisons.map(id => {
+                    const comp = this.blockComparisonManager.getComparisonById(id);
+                    return comp ? `${comp.blocks[0]} vs ${comp.blocks[1]}` : id;
+                })
+            }
+        };
     }
 }

--- a/src/terragrunt/comparisons.ts
+++ b/src/terragrunt/comparisons.ts
@@ -1,0 +1,1422 @@
+/**
+ * Block Comparison Manager
+ * 
+ * Provides functionality to compare similar HCL blocks and offer
+ * pattern guidance for common Terragrunt configuration scenarios.
+ */
+
+import {
+  BlockComparison,
+  BlockComparisonResult,
+  PatternGuidance,
+  PatternGuidanceResult,
+  SearchMatch,
+} from '../types/comparisons.js';
+
+// ============================================================================
+// STATIC BLOCK COMPARISONS
+// ============================================================================
+
+/**
+ * Curated block comparisons for commonly confused HCL blocks
+ */
+const BLOCK_COMPARISONS: BlockComparison[] = [
+  // ---------------------------------------------------------------------------
+  // dependency vs dependencies
+  // ---------------------------------------------------------------------------
+  {
+    id: 'dependency-vs-dependencies',
+    blocks: ['dependency', 'dependencies'],
+    summary: 'dependency defines a single module dependency with output access; dependencies lists modules that must run first without output access.',
+    block1Details: {
+      name: 'dependency',
+      purpose: 'Declare a dependency on another Terragrunt module and access its outputs',
+      syntax: `dependency "vpc" {
+  config_path = "../vpc"
+  
+  mock_outputs = {
+    vpc_id = "mock-vpc-id"
+  }
+}
+
+inputs = {
+  vpc_id = dependency.vpc.outputs.vpc_id
+}`,
+      keyFeatures: [
+        'Access outputs from dependent module via dependency.<name>.outputs',
+        'Supports mock_outputs for plan/validate without applying dependencies',
+        'Each dependency block has a unique name for reference',
+        'Automatically determines execution order',
+        'Can skip outputs with skip_outputs = true for performance',
+      ],
+    },
+    block2Details: {
+      name: 'dependencies',
+      purpose: 'Declare execution order dependencies without needing output access',
+      syntax: `dependencies {
+  paths = ["../vpc", "../security-group", "../iam"]
+}`,
+      keyFeatures: [
+        'Simple list of paths that must be applied first',
+        'No access to outputs from listed modules',
+        'Lightweight - no state file reading required',
+        'Useful for ordering when outputs are not needed',
+        'Can combine with dependency blocks',
+      ],
+    },
+    keyDifferences: [
+      {
+        aspect: 'Output Access',
+        block1: 'Full access to dependent module outputs',
+        block2: 'No output access - ordering only',
+      },
+      {
+        aspect: 'Syntax',
+        block1: 'Named block with config_path attribute',
+        block2: 'Single block with paths list',
+      },
+      {
+        aspect: 'Performance',
+        block1: 'Reads state file to get outputs (slower)',
+        block2: 'No state reading required (faster)',
+      },
+      {
+        aspect: 'Mock Support',
+        block1: 'Supports mock_outputs for planning',
+        block2: 'Not applicable - no outputs to mock',
+      },
+      {
+        aspect: 'Use Case',
+        block1: 'When you need values from another module',
+        block2: 'When you only need execution ordering',
+      },
+    ],
+    whenToUse: {
+      useBlock1When: [
+        'You need to pass outputs from one module to another (e.g., VPC ID)',
+        'You want to validate configurations with mock values before dependencies exist',
+        'You need conditional logic based on dependency outputs',
+        'You want explicit, named references in your inputs block',
+      ],
+      useBlock2When: [
+        'You only need to ensure modules run in a specific order',
+        'Performance is critical and you don\'t need output values',
+        'You have many dependencies but only need ordering guarantees',
+        'The dependent modules don\'t expose outputs you need',
+      ],
+    },
+    commonMistakes: [
+      'Using dependencies when you actually need output values (no outputs.* available)',
+      'Creating dependency blocks for every module when only ordering is needed (performance impact)',
+      'Forgetting mock_outputs when using dependency - causes failures during plan before deps exist',
+      'Circular dependency references between modules',
+    ],
+    relatedDocs: [
+      'https://terragrunt.gruntwork.io/docs/reference/config-blocks-and-attributes/#dependency',
+      'https://terragrunt.gruntwork.io/docs/reference/config-blocks-and-attributes/#dependencies',
+    ],
+  },
+
+  // ---------------------------------------------------------------------------
+  // include (single) vs multiple includes
+  // ---------------------------------------------------------------------------
+  {
+    id: 'include-single-vs-multiple',
+    blocks: ['include', 'multiple includes'],
+    summary: 'A single include inherits from one parent config; multiple includes allow composing configuration from several sources.',
+    block1Details: {
+      name: 'include (single)',
+      purpose: 'Inherit configuration from a single parent terragrunt.hcl file',
+      syntax: `include "root" {
+  path = find_in_parent_folders()
+}`,
+      keyFeatures: [
+        'Inherits all configuration from parent',
+        'Supports expose = true to access parent locals',
+        'Can merge or override parent values',
+        'Traditional DRY pattern for Terragrunt',
+        'Simple inheritance model',
+      ],
+    },
+    block2Details: {
+      name: 'multiple includes',
+      purpose: 'Compose configuration from multiple parent files for modular reuse',
+      syntax: `include "root" {
+  path = find_in_parent_folders()
+}
+
+include "env" {
+  path = find_in_parent_folders("env.hcl")
+  expose = true
+}
+
+include "region" {
+  path = find_in_parent_folders("region.hcl")
+  expose = true
+  merge_strategy = "deep"
+}`,
+      keyFeatures: [
+        'Each include has a unique name',
+        'Can include from different directory levels',
+        'Supports different merge strategies per include',
+        'Access exposed values via include.<name>.*',
+        'Powerful composition for complex projects',
+      ],
+    },
+    keyDifferences: [
+      {
+        aspect: 'Composition',
+        block1: 'Single source of inherited configuration',
+        block2: 'Multiple sources composed together',
+      },
+      {
+        aspect: 'Complexity',
+        block1: 'Simple, linear inheritance',
+        block2: 'More complex, requires understanding merge order',
+      },
+      {
+        aspect: 'Flexibility',
+        block1: 'Limited to one parent\'s configuration',
+        block2: 'Mix and match configurations from multiple files',
+      },
+      {
+        aspect: 'Naming',
+        block1: 'Name is optional (defaults to empty string)',
+        block2: 'Names required to distinguish includes',
+      },
+      {
+        aspect: 'Merge Control',
+        block1: 'Single merge with parent',
+        block2: 'Per-include merge_strategy control',
+      },
+    ],
+    whenToUse: {
+      useBlock1When: [
+        'You have a simple project structure with one root config',
+        'All shared configuration lives in a single parent file',
+        'You\'re just starting with Terragrunt and want simplicity',
+        'Your configuration hierarchy is strictly linear',
+      ],
+      useBlock2When: [
+        'You want to separate concerns (env config, region config, common config)',
+        'Different modules need different combinations of shared configs',
+        'You have a complex multi-account, multi-region setup',
+        'You want to compose behavior from reusable config fragments',
+      ],
+    },
+    commonMistakes: [
+      'Not understanding merge order when using multiple includes (last wins for conflicts)',
+      'Forgetting expose = true when trying to access parent locals',
+      'Creating circular include dependencies',
+      'Over-engineering with too many includes when one would suffice',
+    ],
+    relatedDocs: [
+      'https://terragrunt.gruntwork.io/docs/reference/config-blocks-and-attributes/#include',
+      'https://terragrunt.gruntwork.io/docs/features/keep-your-terragrunt-architecture-dry/',
+    ],
+  },
+
+  // ---------------------------------------------------------------------------
+  // inputs vs locals
+  // ---------------------------------------------------------------------------
+  {
+    id: 'inputs-vs-locals',
+    blocks: ['inputs', 'locals'],
+    summary: 'inputs passes values to Terraform as variables; locals defines reusable values within Terragrunt configuration only.',
+    block1Details: {
+      name: 'inputs',
+      purpose: 'Define values that are passed to Terraform as input variables',
+      syntax: `inputs = {
+  environment = "production"
+  instance_type = "t3.medium"
+  vpc_id = dependency.vpc.outputs.vpc_id
+}`,
+      keyFeatures: [
+        'Values become TF_VAR_* environment variables',
+        'Must match Terraform variable definitions',
+        'Can reference locals, dependencies, and functions',
+        'Merged with parent inputs when using include',
+        'The bridge between Terragrunt and Terraform',
+      ],
+    },
+    block2Details: {
+      name: 'locals',
+      purpose: 'Define reusable values for use within Terragrunt configuration',
+      syntax: `locals {
+  environment = "production"
+  account_id = get_aws_account_id()
+  name_prefix = "\${local.environment}-\${local.account_id}"
+}
+
+inputs = {
+  name = local.name_prefix
+}`,
+      keyFeatures: [
+        'Values only available within terragrunt.hcl',
+        'Not passed to Terraform unless used in inputs',
+        'Great for computed values and DRY configuration',
+        'Can use Terragrunt functions',
+        'Can be exposed to child configs via include',
+      ],
+    },
+    keyDifferences: [
+      {
+        aspect: 'Scope',
+        block1: 'Passed to Terraform module',
+        block2: 'Only available in Terragrunt config',
+      },
+      {
+        aspect: 'Purpose',
+        block1: 'Configure Terraform module behavior',
+        block2: 'DRY helper values for Terragrunt',
+      },
+      {
+        aspect: 'Visibility',
+        block1: 'Visible in Terraform plan output',
+        block2: 'Internal to Terragrunt only',
+      },
+      {
+        aspect: 'Inheritance',
+        block1: 'Merged from parent includes',
+        block2: 'Must be explicitly exposed to children',
+      },
+      {
+        aspect: 'Reference Syntax',
+        block1: 'Used directly in Terraform as var.*',
+        block2: 'Referenced as local.* in Terragrunt',
+      },
+    ],
+    whenToUse: {
+      useBlock1When: [
+        'Defining values that Terraform needs to configure resources',
+        'Passing dependency outputs to Terraform',
+        'Setting environment-specific configuration for modules',
+        'Any value that needs to reach the Terraform layer',
+      ],
+      useBlock2When: [
+        'Computing intermediate values used multiple times',
+        'Extracting values from file paths or environment',
+        'Building complex strings or data structures for inputs',
+        'Defining values shared across multiple inputs',
+      ],
+    },
+    commonMistakes: [
+      'Putting computed values directly in inputs instead of using locals for reuse',
+      'Expecting locals to be available in Terraform (they\'re not)',
+      'Forgetting that inputs must match Terraform variable declarations',
+      'Not using expose = true in includes when sharing locals',
+    ],
+    relatedDocs: [
+      'https://terragrunt.gruntwork.io/docs/reference/config-blocks-and-attributes/#inputs',
+      'https://terragrunt.gruntwork.io/docs/reference/config-blocks-and-attributes/#locals',
+    ],
+  },
+
+  // ---------------------------------------------------------------------------
+  // generate vs terraform.source
+  // ---------------------------------------------------------------------------
+  {
+    id: 'generate-vs-terraform-source',
+    blocks: ['generate', 'terraform.source'],
+    summary: 'generate creates additional .tf files in the working directory; terraform.source specifies which Terraform module to use.',
+    block1Details: {
+      name: 'generate',
+      purpose: 'Generate Terraform configuration files dynamically',
+      syntax: `generate "provider" {
+  path      = "provider.tf"
+  if_exists = "overwrite_terragrunt"
+  contents  = <<EOF
+provider "aws" {
+  region = "us-east-1"
+}
+EOF
+}
+
+generate "backend" {
+  path      = "backend.tf"
+  if_exists = "overwrite_terragrunt"
+  contents  = <<EOF
+terraform {
+  backend "s3" {
+    bucket = "my-terraform-state"
+    key    = "\${path_relative_to_include()}/terraform.tfstate"
+    region = "us-east-1"
+  }
+}
+EOF
+}`,
+      keyFeatures: [
+        'Creates .tf files in the Terragrunt working directory',
+        'Commonly used for provider and backend configuration',
+        'Supports if_exists to control overwrite behavior',
+        'Can use Terragrunt functions in contents',
+        'Files are generated before Terraform runs',
+      ],
+    },
+    block2Details: {
+      name: 'terraform.source',
+      purpose: 'Specify the Terraform module source to use',
+      syntax: `terraform {
+  source = "tfr:///terraform-aws-modules/vpc/aws?version=5.0.0"
+}
+
+# Or local source:
+terraform {
+  source = "../../../modules//vpc"
+}
+
+# Or Git source:
+terraform {
+  source = "git::https://github.com/org/modules.git//vpc?ref=v1.0.0"
+}`,
+      keyFeatures: [
+        'Points to Terraform module code',
+        'Supports registry, Git, local, S3, and other sources',
+        'Double-slash (//) separates repo from subdirectory',
+        'Can include version/ref for pinning',
+        'The actual infrastructure code to execute',
+      ],
+    },
+    keyDifferences: [
+      {
+        aspect: 'Purpose',
+        block1: 'Add configuration to existing module',
+        block2: 'Specify which module to run',
+      },
+      {
+        aspect: 'Output',
+        block1: 'Creates .tf files in working directory',
+        block2: 'Downloads/links module source',
+      },
+      {
+        aspect: 'Common Use',
+        block1: 'Providers, backends, common resources',
+        block2: 'Module location (registry, git, local)',
+      },
+      {
+        aspect: 'Required',
+        block1: 'Optional - only when generating files',
+        block2: 'Required - every Terragrunt config needs a source',
+      },
+      {
+        aspect: 'Scope',
+        block1: 'Supplements the module',
+        block2: 'Defines the module itself',
+      },
+    ],
+    whenToUse: {
+      useBlock1When: [
+        'Adding provider configuration to modules that don\'t include it',
+        'Dynamically configuring backend based on environment',
+        'Injecting common resources across all modules',
+        'Creating files that vary per environment/region',
+      ],
+      useBlock2When: [
+        'Always - every Terragrunt module config needs a source',
+        'Pointing to Terraform Registry modules',
+        'Using Git repositories for module code',
+        'Referencing local module directories',
+      ],
+    },
+    commonMistakes: [
+      'Thinking generate replaces terraform.source (they\'re complementary)',
+      'Generating backend.tf when Terragrunt\'s remote_state block is better',
+      'Not using if_exists correctly, causing file conflicts',
+      'Forgetting the double-slash in terraform.source for subdirectories',
+    ],
+    relatedDocs: [
+      'https://terragrunt.gruntwork.io/docs/reference/config-blocks-and-attributes/#generate',
+      'https://terragrunt.gruntwork.io/docs/reference/config-blocks-and-attributes/#terraform',
+    ],
+  },
+
+  // ---------------------------------------------------------------------------
+  // before_hook vs after_hook
+  // ---------------------------------------------------------------------------
+  {
+    id: 'before-hook-vs-after-hook',
+    blocks: ['before_hook', 'after_hook'],
+    summary: 'before_hook runs commands before Terraform; after_hook runs commands after Terraform completes.',
+    block1Details: {
+      name: 'before_hook',
+      purpose: 'Execute commands before Terraform commands run',
+      syntax: `terraform {
+  before_hook "validate_inputs" {
+    commands = ["apply", "plan"]
+    execute  = ["./scripts/validate.sh"]
+  }
+  
+  before_hook "cache_modules" {
+    commands     = ["init"]
+    execute      = ["./scripts/cache-modules.sh"]
+    run_on_error = false
+  }
+}`,
+      keyFeatures: [
+        'Runs before specified Terraform commands',
+        'Can validate, prepare, or set up prerequisites',
+        'run_on_error controls execution on prior hook failures',
+        'Useful for pre-flight checks and setup',
+        'Can abort execution if hook fails',
+      ],
+    },
+    block2Details: {
+      name: 'after_hook',
+      purpose: 'Execute commands after Terraform commands complete',
+      syntax: `terraform {
+  after_hook "notify_slack" {
+    commands = ["apply"]
+    execute  = ["./scripts/notify.sh", "Applied successfully"]
+  }
+  
+  after_hook "cleanup" {
+    commands     = ["apply", "destroy"]
+    execute      = ["./scripts/cleanup.sh"]
+    run_on_error = true
+  }
+}`,
+      keyFeatures: [
+        'Runs after specified Terraform commands',
+        'Can notify, clean up, or post-process',
+        'run_on_error allows cleanup even on failure',
+        'Useful for notifications and logging',
+        'Has access to Terraform command result',
+      ],
+    },
+    keyDifferences: [
+      {
+        aspect: 'Timing',
+        block1: 'Before Terraform command executes',
+        block2: 'After Terraform command completes',
+      },
+      {
+        aspect: 'Abort Behavior',
+        block1: 'Failure prevents Terraform from running',
+        block2: 'Failure happens after Terraform already ran',
+      },
+      {
+        aspect: 'Common Use Cases',
+        block1: 'Validation, setup, pre-flight checks',
+        block2: 'Notifications, cleanup, post-processing',
+      },
+      {
+        aspect: 'Error Context',
+        block1: 'Can\'t know Terraform result (hasn\'t run)',
+        block2: 'Can react to Terraform success/failure',
+      },
+      {
+        aspect: 'Idempotency',
+        block1: 'Should be idempotent (may run multiple times)',
+        block2: 'Should handle partial Terraform completion',
+      },
+    ],
+    whenToUse: {
+      useBlock1When: [
+        'Validating inputs or environment before Terraform runs',
+        'Setting up prerequisites (credentials, files)',
+        'Running pre-flight security or compliance checks',
+        'Caching or preparing external dependencies',
+      ],
+      useBlock2When: [
+        'Sending notifications about apply/destroy results',
+        'Cleaning up temporary files or resources',
+        'Triggering downstream processes after changes',
+        'Logging or auditing Terraform actions',
+      ],
+    },
+    commonMistakes: [
+      'Using after_hook for validation (too late to prevent Terraform)',
+      'Not setting run_on_error = true for cleanup hooks',
+      'Making before_hooks non-idempotent (breaks retries)',
+      'Ignoring hook failures that should abort the operation',
+    ],
+    relatedDocs: [
+      'https://terragrunt.gruntwork.io/docs/reference/config-blocks-and-attributes/#terraform',
+      'https://terragrunt.gruntwork.io/docs/features/hooks/',
+    ],
+  },
+
+  // ---------------------------------------------------------------------------
+  // remote_state vs dependency
+  // ---------------------------------------------------------------------------
+  {
+    id: 'remote-state-vs-dependency',
+    blocks: ['remote_state', 'dependency'],
+    summary: 'remote_state configures where state is stored; dependency references another Terragrunt module\'s outputs.',
+    block1Details: {
+      name: 'remote_state',
+      purpose: 'Configure Terraform backend for state storage',
+      syntax: `remote_state {
+  backend = "s3"
+  generate = {
+    path      = "backend.tf"
+    if_exists = "overwrite_terragrunt"
+  }
+  config = {
+    bucket         = "my-terraform-state"
+    key            = "\${path_relative_to_include()}/terraform.tfstate"
+    region         = "us-east-1"
+    encrypt        = true
+    dynamodb_table = "terraform-locks"
+  }
+}`,
+      keyFeatures: [
+        'Configures Terraform backend (S3, GCS, Azure, etc.)',
+        'Can auto-generate backend.tf file',
+        'Supports automatic bucket/table creation',
+        'Centralizes state configuration in root',
+        'Interpolates path for unique state keys',
+      ],
+    },
+    block2Details: {
+      name: 'dependency',
+      purpose: 'Reference outputs from another Terragrunt-managed module',
+      syntax: `dependency "vpc" {
+  config_path = "../vpc"
+  
+  mock_outputs = {
+    vpc_id = "mock-vpc-id"
+  }
+}
+
+inputs = {
+  vpc_id = dependency.vpc.outputs.vpc_id
+}`,
+      keyFeatures: [
+        'Reads outputs from another module\'s state',
+        'Creates implicit execution ordering',
+        'Supports mock_outputs for planning',
+        'Uses the other module\'s configured backend',
+        'Type-safe output references',
+      ],
+    },
+    keyDifferences: [
+      {
+        aspect: 'Purpose',
+        block1: 'Where to store THIS module\'s state',
+        block2: 'How to read ANOTHER module\'s outputs',
+      },
+      {
+        aspect: 'Direction',
+        block1: 'Outbound - writing state',
+        block2: 'Inbound - reading state',
+      },
+      {
+        aspect: 'Scope',
+        block1: 'One per module (the backend config)',
+        block2: 'Multiple per module (one per dependency)',
+      },
+      {
+        aspect: 'State Access',
+        block1: 'Configures access credentials and location',
+        block2: 'Uses dependency\'s remote_state to read',
+      },
+      {
+        aspect: 'Required',
+        block1: 'Required for any module storing state remotely',
+        block2: 'Only when you need another module\'s outputs',
+      },
+    ],
+    whenToUse: {
+      useBlock1When: [
+        'Configuring where Terraform stores its state file',
+        'Setting up state locking with DynamoDB/equivalent',
+        'Enabling encryption for state files',
+        'Defining consistent state paths across environments',
+      ],
+      useBlock2When: [
+        'Passing values between Terragrunt modules',
+        'Creating execution order based on data flow',
+        'Reading VPC IDs, ARNs, or other outputs from infrastructure',
+        'Building a dependency graph for run-all commands',
+      ],
+    },
+    commonMistakes: [
+      'Confusing remote_state (backend config) with dependency (output reading)',
+      'Trying to use dependency to configure where state is stored',
+      'Not realizing dependency reads FROM the other module\'s remote_state',
+      'Forgetting that remote_state is about YOUR state, dependency is about OTHERS\' state',
+    ],
+    relatedDocs: [
+      'https://terragrunt.gruntwork.io/docs/reference/config-blocks-and-attributes/#remote_state',
+      'https://terragrunt.gruntwork.io/docs/reference/config-blocks-and-attributes/#dependency',
+    ],
+  },
+];
+
+// ============================================================================
+// STATIC PATTERN GUIDANCE
+// ============================================================================
+
+/**
+ * Curated pattern guidance for common configuration scenarios
+ */
+const PATTERN_GUIDANCE: PatternGuidance[] = [
+  // ---------------------------------------------------------------------------
+  // Module Dependency Management
+  // ---------------------------------------------------------------------------
+  {
+    id: 'module-dependency-management',
+    scenario: 'Managing dependencies between Terraform modules',
+    question: 'How should I manage dependencies between my Terragrunt modules?',
+    keywords: ['dependency', 'dependencies', 'outputs', 'order', 'execution', 'dag', 'graph'],
+    decisionCriteria: [
+      {
+        criterion: 'You need to pass output values from one module to another',
+        recommendation: 'Use dependency blocks',
+        reason: 'dependency blocks expose .outputs for accessing values like VPC IDs, ARNs, etc.',
+      },
+      {
+        criterion: 'You only need modules to run in a specific order, no data passing',
+        recommendation: 'Use dependencies block',
+        reason: 'dependencies is lighter weight - no state reading, just ordering',
+      },
+      {
+        criterion: 'You have many dependencies but only need a few outputs',
+        recommendation: 'Mix dependency and dependencies',
+        reason: 'Use dependency for modules with outputs you need, dependencies for ordering-only',
+      },
+      {
+        criterion: 'You want to plan before dependent modules exist',
+        recommendation: 'Use dependency with mock_outputs',
+        reason: 'mock_outputs provides fake values for planning without real dependencies',
+      },
+    ],
+    patterns: [
+      {
+        name: 'Explicit Output Dependencies',
+        description: 'Use named dependency blocks for each module whose outputs you need',
+        example: `dependency "vpc" {
+  config_path = "../vpc"
+  mock_outputs = {
+    vpc_id         = "mock-vpc-id"
+    public_subnets = ["subnet-1", "subnet-2"]
+  }
+}
+
+dependency "security_group" {
+  config_path = "../security-group"
+  mock_outputs = {
+    security_group_id = "mock-sg-id"
+  }
+}
+
+inputs = {
+  vpc_id            = dependency.vpc.outputs.vpc_id
+  subnet_ids        = dependency.vpc.outputs.public_subnets
+  security_group_id = dependency.security_group.outputs.security_group_id
+}`,
+        pros: [
+          'Clear, explicit data flow',
+          'Supports mock values for planning',
+          'Self-documenting dependencies',
+        ],
+        cons: [
+          'Reads state files (slower for many dependencies)',
+          'Must maintain mock_outputs',
+        ],
+      },
+      {
+        name: 'Order-Only Dependencies',
+        description: 'Use dependencies block when you only need execution ordering',
+        example: `dependencies {
+  paths = ["../iam-roles", "../kms-keys", "../logging"]
+}
+
+# No inputs from these - just need them to exist first`,
+        pros: [
+          'Fast - no state file reading',
+          'Simple syntax for multiple deps',
+          'Good for foundational resources',
+        ],
+        cons: [
+          'Cannot access output values',
+          'Less explicit about WHY the dependency exists',
+        ],
+      },
+      {
+        name: 'Hybrid Approach',
+        description: 'Combine both patterns based on actual data needs',
+        example: `# Need outputs from VPC
+dependency "vpc" {
+  config_path = "../vpc"
+  mock_outputs = { vpc_id = "mock" }
+}
+
+# Only need ordering for these
+dependencies {
+  paths = ["../iam-roles", "../cloudwatch-logs"]
+}
+
+inputs = {
+  vpc_id = dependency.vpc.outputs.vpc_id
+}`,
+        pros: [
+          'Optimized - only reads state when needed',
+          'Clear distinction between data and ordering deps',
+          'Best of both patterns',
+        ],
+        cons: [
+          'Slightly more complex to understand',
+          'Must decide per-dependency which to use',
+        ],
+      },
+    ],
+    relatedComparisons: ['dependency-vs-dependencies'],
+  },
+
+  // ---------------------------------------------------------------------------
+  // Configuration Inheritance
+  // ---------------------------------------------------------------------------
+  {
+    id: 'configuration-inheritance',
+    scenario: 'DRY configuration inheritance across environments and regions',
+    question: 'How should I structure configuration inheritance in my Terragrunt project?',
+    keywords: ['include', 'inherit', 'dry', 'parent', 'root', 'common', 'shared', 'merge'],
+    decisionCriteria: [
+      {
+        criterion: 'Simple project with one level of shared config',
+        recommendation: 'Use single include with find_in_parent_folders()',
+        reason: 'Straightforward inheritance from one root.hcl file',
+      },
+      {
+        criterion: 'Multi-account/multi-region with different config layers',
+        recommendation: 'Use multiple named includes',
+        reason: 'Compose config from account.hcl, region.hcl, env.hcl, and root.hcl',
+      },
+      {
+        criterion: 'Need to access parent locals in child configs',
+        recommendation: 'Use expose = true on include blocks',
+        reason: 'Exposes parent locals as include.<name>.locals.*',
+      },
+      {
+        criterion: 'Complex merging requirements',
+        recommendation: 'Use merge_strategy per include',
+        reason: 'Control how each include\'s values merge with local config',
+      },
+    ],
+    patterns: [
+      {
+        name: 'Simple Root Include',
+        description: 'Single parent file for all shared configuration',
+        example: `# In modules/app/terragrunt.hcl:
+include "root" {
+  path = find_in_parent_folders()
+}
+
+# Root terragrunt.hcl contains remote_state, common inputs, etc.`,
+        pros: [
+          'Simple to understand',
+          'One place for all shared config',
+          'Easy to get started',
+        ],
+        cons: [
+          'Can become monolithic',
+          'Hard to have env-specific overrides',
+          'All or nothing inheritance',
+        ],
+      },
+      {
+        name: 'Layered Includes',
+        description: 'Multiple include files for different concerns',
+        example: `include "root" {
+  path = find_in_parent_folders("root.hcl")
+}
+
+include "env" {
+  path   = find_in_parent_folders("env.hcl")
+  expose = true
+}
+
+include "region" {
+  path           = find_in_parent_folders("region.hcl")
+  expose         = true
+  merge_strategy = "deep"
+}
+
+locals {
+  env    = include.env.locals.environment
+  region = include.region.locals.aws_region
+}`,
+        pros: [
+          'Separation of concerns',
+          'Easy to override at any level',
+          'Flexible composition',
+        ],
+        cons: [
+          'More files to manage',
+          'Must understand merge order',
+          'Can be confusing for newcomers',
+        ],
+      },
+      {
+        name: 'Environment-Specific Overrides',
+        description: 'Common base with environment-specific configurations',
+        example: `# Directory structure:
+# ├── _envcommon/
+# │   └── app.hcl        # Common app config
+# ├── prod/
+# │   └── app/
+# │       └── terragrunt.hcl
+# └── dev/
+#     └── app/
+#         └── terragrunt.hcl
+
+# In prod/app/terragrunt.hcl:
+include "root" {
+  path = find_in_parent_folders()
+}
+
+include "envcommon" {
+  path   = "\${dirname(find_in_parent_folders())}/_envcommon/app.hcl"
+  expose = true
+}
+
+inputs = {
+  # Override envcommon defaults for prod
+  instance_type = "m5.xlarge"
+}`,
+        pros: [
+          'Shared module config with env overrides',
+          'Clear what\'s common vs environment-specific',
+          'Scales well for many environments',
+        ],
+        cons: [
+          '_envcommon pattern has learning curve',
+          'Path calculations can be complex',
+          'Requires disciplined structure',
+        ],
+      },
+    ],
+    relatedComparisons: ['include-single-vs-multiple'],
+  },
+
+  // ---------------------------------------------------------------------------
+  // Backend and State Management
+  // ---------------------------------------------------------------------------
+  {
+    id: 'backend-state-management',
+    scenario: 'Configuring Terraform state storage and backend',
+    question: 'How should I configure my Terraform backend in Terragrunt?',
+    keywords: ['backend', 'state', 'remote_state', 's3', 'gcs', 'azure', 'storage', 'lock', 'dynamodb'],
+    decisionCriteria: [
+      {
+        criterion: 'Need automatic backend configuration with state locking',
+        recommendation: 'Use remote_state with generate = true',
+        reason: 'Terragrunt generates backend.tf and can create bucket/table automatically',
+      },
+      {
+        criterion: 'Backend already configured in Terraform module',
+        recommendation: 'Use remote_state with generate = false or skip it',
+        reason: 'Avoid conflicts with existing backend configuration',
+      },
+      {
+        criterion: 'Different backends for different environments',
+        recommendation: 'Define remote_state in environment-level includes',
+        reason: 'Each env can have its own state bucket/configuration',
+      },
+      {
+        criterion: 'Need to reference state from other modules',
+        recommendation: 'Use dependency blocks, not direct state access',
+        reason: 'dependency provides typed access to outputs with mock support',
+      },
+    ],
+    patterns: [
+      {
+        name: 'Centralized S3 Backend',
+        description: 'Single state bucket with path-based keys',
+        example: `# In root terragrunt.hcl:
+remote_state {
+  backend = "s3"
+  generate = {
+    path      = "backend.tf"
+    if_exists = "overwrite_terragrunt"
+  }
+  config = {
+    bucket         = "company-terraform-state"
+    key            = "\${path_relative_to_include()}/terraform.tfstate"
+    region         = "us-east-1"
+    encrypt        = true
+    dynamodb_table = "terraform-state-lock"
+    
+    # Auto-create bucket and table
+    skip_bucket_versioning         = false
+    skip_bucket_ssencryption       = false
+    enable_lock_table_ssencryption = true
+  }
+}`,
+        pros: [
+          'Single bucket for all state',
+          'Automatic key paths prevent collisions',
+          'Centralized lock table',
+        ],
+        cons: [
+          'All eggs in one basket (bucket)',
+          'Permissions management for single bucket',
+          'Cross-account access can be complex',
+        ],
+      },
+      {
+        name: 'Per-Environment Backends',
+        description: 'Separate state storage per environment',
+        example: `# In environments/prod/env.hcl:
+locals {
+  environment = "prod"
+}
+
+remote_state {
+  backend = "s3"
+  generate = {
+    path      = "backend.tf"
+    if_exists = "overwrite_terragrunt"
+  }
+  config = {
+    bucket         = "prod-terraform-state"
+    key            = "\${path_relative_to_include()}/terraform.tfstate"
+    region         = "us-east-1"
+    encrypt        = true
+    dynamodb_table = "prod-terraform-locks"
+  }
+}
+
+# In environments/dev/env.hcl - similar but different bucket`,
+        pros: [
+          'Isolation between environments',
+          'Different permissions per env',
+          'Easier disaster recovery',
+        ],
+        cons: [
+          'More buckets/tables to manage',
+          'Cross-env dependencies more complex',
+          'Duplicate configuration',
+        ],
+      },
+      {
+        name: 'Workspaces Alternative',
+        description: 'Use Terragrunt directory structure instead of Terraform workspaces',
+        example: `# Instead of workspaces, use directory structure:
+# environments/
+# ├── dev/us-east-1/vpc/terragrunt.hcl
+# ├── staging/us-east-1/vpc/terragrunt.hcl
+# └── prod/us-east-1/vpc/terragrunt.hcl
+
+# Each gets unique state key via path_relative_to_include():
+# dev/us-east-1/vpc/terraform.tfstate
+# staging/us-east-1/vpc/terraform.tfstate
+# prod/us-east-1/vpc/terraform.tfstate`,
+        pros: [
+          'Explicit, visible environment separation',
+          'No workspace switching needed',
+          'Full isolation by default',
+        ],
+        cons: [
+          'More directories to navigate',
+          'Duplicate module configurations',
+          'Different from Terraform-native approach',
+        ],
+      },
+    ],
+    relatedComparisons: ['remote-state-vs-dependency', 'generate-vs-terraform-source'],
+  },
+];
+
+// ============================================================================
+// BLOCK COMPARISON MANAGER CLASS
+// ============================================================================
+
+/**
+ * Manager for block comparisons and pattern guidance.
+ * Provides search and lookup functionality for helping users
+ * understand differences between similar HCL blocks and choose
+ * appropriate configuration patterns.
+ */
+export class BlockComparisonManager {
+  private comparisons: Map<string, BlockComparison>;
+  private patterns: Map<string, PatternGuidance>;
+  private blockIndex: Map<string, string[]>; // block name -> comparison IDs
+  private keywordIndex: Map<string, string[]>; // keyword -> pattern IDs
+
+  constructor() {
+    this.comparisons = new Map();
+    this.patterns = new Map();
+    this.blockIndex = new Map();
+    this.keywordIndex = new Map();
+    this.initializeData();
+  }
+
+  /**
+   * Initialize indices from static data
+   */
+  private initializeData(): void {
+    // Index comparisons
+    for (const comparison of BLOCK_COMPARISONS) {
+      this.comparisons.set(comparison.id, comparison);
+      
+      // Index both blocks
+      for (const block of comparison.blocks) {
+        const normalized = this.normalizeBlockName(block);
+        const existing = this.blockIndex.get(normalized) || [];
+        existing.push(comparison.id);
+        this.blockIndex.set(normalized, existing);
+      }
+    }
+
+    // Index patterns
+    for (const pattern of PATTERN_GUIDANCE) {
+      this.patterns.set(pattern.id, pattern);
+      
+      // Index keywords
+      for (const keyword of pattern.keywords) {
+        const normalized = keyword.toLowerCase();
+        const existing = this.keywordIndex.get(normalized) || [];
+        existing.push(pattern.id);
+        this.keywordIndex.set(normalized, existing);
+      }
+    }
+  }
+
+  /**
+   * Normalize a block name for consistent lookup
+   */
+  private normalizeBlockName(name: string): string {
+    return name.toLowerCase()
+      .replace(/[^a-z0-9_]/g, '')
+      .replace(/^terraform_?/, '') // Remove terraform prefix
+      .replace(/_block$/, ''); // Remove _block suffix
+  }
+
+  /**
+   * Calculate string similarity using Levenshtein distance
+   */
+  private calculateStringSimilarity(str1: string, str2: string): number {
+    const s1 = str1.toLowerCase();
+    const s2 = str2.toLowerCase();
+    
+    if (s1 === s2) return 1;
+    if (s1.length === 0 || s2.length === 0) return 0;
+
+    // Check for substring match
+    if (s1.includes(s2) || s2.includes(s1)) {
+      return 0.8;
+    }
+
+    // Levenshtein distance
+    const matrix: number[][] = [];
+    
+    for (let i = 0; i <= s1.length; i++) {
+      matrix[i] = [i];
+    }
+    for (let j = 0; j <= s2.length; j++) {
+      matrix[0][j] = j;
+    }
+
+    for (let i = 1; i <= s1.length; i++) {
+      for (let j = 1; j <= s2.length; j++) {
+        const cost = s1[i - 1] === s2[j - 1] ? 0 : 1;
+        matrix[i][j] = Math.min(
+          matrix[i - 1][j] + 1,
+          matrix[i][j - 1] + 1,
+          matrix[i - 1][j - 1] + cost
+        );
+      }
+    }
+
+    const distance = matrix[s1.length][s2.length];
+    const maxLength = Math.max(s1.length, s2.length);
+    return 1 - (distance / maxLength);
+  }
+
+  /**
+   * Find best matching block name using fuzzy matching
+   */
+  private findBestBlockMatch(query: string): { block: string; score: number } | null {
+    const normalized = this.normalizeBlockName(query);
+    
+    // Exact match
+    if (this.blockIndex.has(normalized)) {
+      return { block: normalized, score: 1 };
+    }
+
+    // Fuzzy match against all known blocks
+    let bestMatch: { block: string; score: number } | null = null;
+    
+    for (const block of this.blockIndex.keys()) {
+      const score = this.calculateStringSimilarity(normalized, block);
+      if (score > 0.6 && (!bestMatch || score > bestMatch.score)) {
+        bestMatch = { block, score };
+      }
+    }
+
+    return bestMatch;
+  }
+
+  /**
+   * Parse a comparison query like "dependency vs dependencies"
+   */
+  private parseComparisonQuery(query: string): { block1: string; block2: string } | null {
+    // Try to split on common separators
+    const separators = [' vs ', ' versus ', ' compared to ', ' or ', ' and '];
+    
+    for (const sep of separators) {
+      if (query.toLowerCase().includes(sep)) {
+        const parts = query.toLowerCase().split(sep);
+        if (parts.length === 2) {
+          return {
+            block1: parts[0].trim(),
+            block2: parts[1].trim(),
+          };
+        }
+      }
+    }
+
+    return null;
+  }
+
+  // ==========================================================================
+  // PUBLIC API
+  // ==========================================================================
+
+  /**
+   * Compare two HCL blocks.
+   * Accepts either two separate block names or a natural language query.
+   * 
+   * @param block1OrQuery First block name or query like "dependency vs dependencies"
+   * @param block2 Optional second block name
+   * @returns Comparison result with details or suggestions
+   */
+  compareBlocks(block1OrQuery: string, block2?: string): BlockComparisonResult {
+    let searchBlock1: string;
+    let searchBlock2: string;
+
+    // Parse query if only one argument
+    if (!block2) {
+      const parsed = this.parseComparisonQuery(block1OrQuery);
+      if (parsed) {
+        searchBlock1 = parsed.block1;
+        searchBlock2 = parsed.block2;
+      } else {
+        // Single block - suggest comparisons involving it
+        const match = this.findBestBlockMatch(block1OrQuery);
+        if (match) {
+          const comparisonIds = this.blockIndex.get(match.block) || [];
+          const suggestions = comparisonIds.map(id => {
+            const comp = this.comparisons.get(id)!;
+            return `${comp.blocks[0]} vs ${comp.blocks[1]}`;
+          });
+          return {
+            found: false,
+            suggestions,
+            error: `Please specify two blocks to compare. Available comparisons for "${block1OrQuery}": ${suggestions.join(', ')}`,
+          };
+        }
+        return {
+          found: false,
+          suggestions: this.getAvailableComparisons(),
+          error: `Could not parse comparison query. Try: "block1 vs block2" or specify two blocks.`,
+        };
+      }
+    } else {
+      searchBlock1 = block1OrQuery;
+      searchBlock2 = block2;
+    }
+
+    // Find matches for both blocks
+    const match1 = this.findBestBlockMatch(searchBlock1);
+    const match2 = this.findBestBlockMatch(searchBlock2);
+
+    if (!match1) {
+      return {
+        found: false,
+        suggestions: [...this.blockIndex.keys()],
+        error: `Unknown block: "${searchBlock1}". Available blocks: ${[...this.blockIndex.keys()].join(', ')}`,
+      };
+    }
+
+    if (!match2) {
+      return {
+        found: false,
+        suggestions: [...this.blockIndex.keys()],
+        error: `Unknown block: "${searchBlock2}". Available blocks: ${[...this.blockIndex.keys()].join(', ')}`,
+      };
+    }
+
+    // Find comparison containing both blocks
+    const ids1 = new Set(this.blockIndex.get(match1.block) || []);
+    const ids2 = new Set(this.blockIndex.get(match2.block) || []);
+    
+    const commonIds = [...ids1].filter(id => ids2.has(id));
+
+    if (commonIds.length === 0) {
+      return {
+        found: false,
+        suggestions: this.getAvailableComparisons(),
+        error: `No comparison available for "${searchBlock1}" vs "${searchBlock2}". Available comparisons: ${this.getAvailableComparisons().join(', ')}`,
+      };
+    }
+
+    const comparison = this.comparisons.get(commonIds[0])!;
+    return {
+      found: true,
+      comparison,
+    };
+  }
+
+  /**
+   * Get pattern guidance for a scenario or by keywords.
+   * 
+   * @param query Scenario description or keywords
+   * @returns Pattern guidance result with recommendations
+   */
+  getPatternGuidance(query: string): PatternGuidanceResult {
+    const queryLower = query.toLowerCase();
+    const queryWords = queryLower.split(/\s+/).filter(w => w.length > 2);
+
+    // Direct ID match
+    for (const [id, pattern] of this.patterns) {
+      if (queryLower.includes(id.replace(/-/g, ' ')) || 
+          id.replace(/-/g, ' ').includes(queryLower)) {
+        return { found: true, guidance: pattern };
+      }
+    }
+
+    // Keyword matching with scoring
+    const scores: SearchMatch<PatternGuidance>[] = [];
+
+    for (const [, pattern] of this.patterns) {
+      let score = 0;
+      const matchedOn: string[] = [];
+
+      // Check keywords
+      for (const keyword of pattern.keywords) {
+        if (queryLower.includes(keyword.toLowerCase())) {
+          score += 0.3;
+          matchedOn.push(`keyword:${keyword}`);
+        }
+      }
+
+      // Check scenario
+      const scenarioWords = pattern.scenario.toLowerCase().split(/\s+/);
+      for (const word of queryWords) {
+        if (scenarioWords.some(sw => sw.includes(word) || word.includes(sw))) {
+          score += 0.2;
+          matchedOn.push(`scenario:${word}`);
+        }
+      }
+
+      // Check question
+      if (pattern.question.toLowerCase().includes(queryLower) ||
+          queryLower.includes(pattern.question.toLowerCase().replace(/\?/g, ''))) {
+        score += 0.5;
+        matchedOn.push('question');
+      }
+
+      if (score > 0) {
+        scores.push({ item: pattern, score: Math.min(score, 1), matchedOn });
+      }
+    }
+
+    // Sort by score
+    scores.sort((a, b) => b.score - a.score);
+
+    if (scores.length > 0 && scores[0].score > 0.3) {
+      return { found: true, guidance: scores[0].item };
+    }
+
+    // Return suggestions
+    const suggestions = [...this.patterns.values()].map(p => p.scenario);
+    return {
+      found: false,
+      suggestions,
+      error: `No pattern guidance found for "${query}". Available topics: ${suggestions.join('; ')}`,
+    };
+  }
+
+  /**
+   * Get all available block comparisons
+   */
+  getAvailableComparisons(): string[] {
+    return [...this.comparisons.values()].map(c => `${c.blocks[0]} vs ${c.blocks[1]}`);
+  }
+
+  /**
+   * Get all available pattern guidance topics
+   */
+  getAvailablePatterns(): string[] {
+    return [...this.patterns.values()].map(p => p.scenario);
+  }
+
+  /**
+   * Get a specific comparison by ID
+   */
+  getComparisonById(id: string): BlockComparison | undefined {
+    return this.comparisons.get(id);
+  }
+
+  /**
+   * Get specific pattern guidance by ID
+   */
+  getPatternById(id: string): PatternGuidance | undefined {
+    return this.patterns.get(id);
+  }
+
+  /**
+   * List all comparison IDs
+   */
+  listComparisonIds(): string[] {
+    return [...this.comparisons.keys()];
+  }
+
+  /**
+   * List all pattern guidance IDs
+   */
+  listPatternIds(): string[] {
+    return [...this.patterns.keys()];
+  }
+
+  /**
+   * Search comparisons by keyword
+   */
+  searchComparisons(query: string): SearchMatch<BlockComparison>[] {
+    const queryLower = query.toLowerCase();
+    const results: SearchMatch<BlockComparison>[] = [];
+
+    for (const comparison of this.comparisons.values()) {
+      let score = 0;
+      const matchedOn: string[] = [];
+
+      // Check block names
+      for (const block of comparison.blocks) {
+        if (block.toLowerCase().includes(queryLower) || 
+            queryLower.includes(block.toLowerCase())) {
+          score += 0.4;
+          matchedOn.push(`block:${block}`);
+        }
+      }
+
+      // Check summary
+      if (comparison.summary.toLowerCase().includes(queryLower)) {
+        score += 0.3;
+        matchedOn.push('summary');
+      }
+
+      // Check key differences
+      for (const diff of comparison.keyDifferences) {
+        if (diff.aspect.toLowerCase().includes(queryLower) ||
+            diff.block1.toLowerCase().includes(queryLower) ||
+            diff.block2.toLowerCase().includes(queryLower)) {
+          score += 0.2;
+          matchedOn.push(`difference:${diff.aspect}`);
+        }
+      }
+
+      if (score > 0) {
+        results.push({ item: comparison, score: Math.min(score, 1), matchedOn });
+      }
+    }
+
+    return results.sort((a, b) => b.score - a.score);
+  }
+}
+
+// Export singleton instance for convenience
+export const blockComparisonManager = new BlockComparisonManager();

--- a/src/types/comparisons.ts
+++ b/src/types/comparisons.ts
@@ -1,0 +1,151 @@
+/**
+ * Type definitions for HCL block comparisons and pattern guidance
+ */
+
+/**
+ * Details about a single HCL block in a comparison
+ */
+export interface BlockDetails {
+  /** Block name (e.g., "dependency") */
+  name: string;
+  /** Brief description of the block's purpose */
+  purpose: string;
+  /** HCL syntax example */
+  syntax: string;
+  /** Key features/capabilities of this block */
+  keyFeatures: string[];
+}
+
+/**
+ * A single difference aspect between two blocks
+ */
+export interface DifferenceAspect {
+  /** The aspect being compared (e.g., "Cardinality", "Use Case") */
+  aspect: string;
+  /** How block1 handles this aspect */
+  block1: string;
+  /** How block2 handles this aspect */
+  block2: string;
+}
+
+/**
+ * Guidance on when to use each block
+ */
+export interface UsageGuidance {
+  /** Scenarios where block1 is the better choice */
+  useBlock1When: string[];
+  /** Scenarios where block2 is the better choice */
+  useBlock2When: string[];
+}
+
+/**
+ * Complete comparison between two HCL blocks
+ */
+export interface BlockComparison {
+  /** Unique identifier (e.g., "dependency-vs-dependencies") */
+  id: string;
+  /** The two blocks being compared */
+  blocks: [string, string];
+  /** Brief one-line summary of the comparison */
+  summary: string;
+  /** Detailed information about the first block */
+  block1Details: BlockDetails;
+  /** Detailed information about the second block */
+  block2Details: BlockDetails;
+  /** Point-by-point differences */
+  keyDifferences: DifferenceAspect[];
+  /** When to use each block */
+  whenToUse: UsageGuidance;
+  /** Common mistakes users make with these blocks */
+  commonMistakes: string[];
+  /** Related documentation URLs or references */
+  relatedDocs: string[];
+}
+
+/**
+ * Result of a block comparison lookup
+ */
+export interface BlockComparisonResult {
+  /** Whether a comparison was found */
+  found: boolean;
+  /** The comparison if found */
+  comparison?: BlockComparison;
+  /** Alternative suggestions if exact match not found */
+  suggestions?: string[];
+  /** Error message if applicable */
+  error?: string;
+}
+
+/**
+ * A single decision criterion for choosing a pattern
+ */
+export interface DecisionCriterion {
+  /** The criterion to evaluate (e.g., "Need to reference outputs from another module") */
+  criterion: string;
+  /** The recommended pattern/approach */
+  recommendation: string;
+  /** Why this recommendation makes sense */
+  reason: string;
+}
+
+/**
+ * A configuration pattern with its trade-offs
+ */
+export interface ConfigurationPattern {
+  /** Pattern name (e.g., "Explicit Dependencies") */
+  name: string;
+  /** Description of what this pattern does */
+  description: string;
+  /** HCL code example */
+  example: string;
+  /** Advantages of this pattern */
+  pros: string[];
+  /** Disadvantages or limitations */
+  cons: string[];
+}
+
+/**
+ * Complete guidance for a configuration scenario
+ */
+export interface PatternGuidance {
+  /** Unique identifier (e.g., "module-dependency-management") */
+  id: string;
+  /** Human-readable scenario description */
+  scenario: string;
+  /** The question this guidance answers */
+  question: string;
+  /** Keywords for search matching */
+  keywords: string[];
+  /** Decision criteria to help choose */
+  decisionCriteria: DecisionCriterion[];
+  /** Available patterns with trade-offs */
+  patterns: ConfigurationPattern[];
+  /** IDs of related block comparisons */
+  relatedComparisons: string[];
+}
+
+/**
+ * Result of a pattern guidance lookup
+ */
+export interface PatternGuidanceResult {
+  /** Whether guidance was found */
+  found: boolean;
+  /** The guidance if found */
+  guidance?: PatternGuidance;
+  /** Alternative suggestions if exact match not found */
+  suggestions?: string[];
+  /** Error message if applicable */
+  error?: string;
+}
+
+/**
+ * Search match with relevance score
+ */
+export interface SearchMatch<T> {
+  /** The matched item */
+  item: T;
+  /** Relevance score (0-1) */
+  score: number;
+  /** Which field(s) matched */
+  matchedOn: string[];
+}

--- a/test/integration/block-comparison.test.ts
+++ b/test/integration/block-comparison.test.ts
@@ -1,0 +1,377 @@
+/**
+ * Integration tests for block comparison and pattern guidance tools
+ */
+
+import { describe, it, expect, beforeEach } from 'vitest';
+import { ToolHandler } from '../../src/handlers/tools.js';
+
+describe('Block Comparison and Pattern Guidance Tools', () => {
+  let toolHandler: ToolHandler;
+
+  beforeEach(() => {
+    toolHandler = new ToolHandler();
+  });
+
+  describe('Tool Registration', () => {
+    it('should register compare_hcl_blocks tool', () => {
+      const tools = toolHandler.getAvailableTools();
+      const compareTool = tools.find(t => t.name === 'compare_hcl_blocks');
+      
+      expect(compareTool).toBeDefined();
+      expect(compareTool!.description).toContain('Compare two similar HCL blocks');
+      expect(compareTool!.inputSchema.properties.block1).toBeDefined();
+      expect(compareTool!.inputSchema.properties.block2).toBeDefined();
+      expect(compareTool!.inputSchema.properties.listComparisons).toBeDefined();
+    });
+
+    it('should register get_pattern_guidance tool', () => {
+      const tools = toolHandler.getAvailableTools();
+      const guidanceTool = tools.find(t => t.name === 'get_pattern_guidance');
+      
+      expect(guidanceTool).toBeDefined();
+      expect(guidanceTool!.description).toContain('guidance');
+      expect(guidanceTool!.inputSchema.properties.scenario).toBeDefined();
+      expect(guidanceTool!.inputSchema.properties.listPatterns).toBeDefined();
+    });
+  });
+
+  describe('compare_hcl_blocks tool', () => {
+    describe('listing comparisons', () => {
+      it('should list all available comparisons', async () => {
+        const result = await toolHandler.executeTool('compare_hcl_blocks', {
+          listComparisons: true
+        });
+        
+        expect(result.availableComparisons).toBeDefined();
+        expect(result.availableComparisons.length).toBeGreaterThanOrEqual(5);
+        expect(result.availableComparisons).toContain('dependency vs dependencies');
+        expect(result.usage).toBeDefined();
+      });
+    });
+
+    describe('comparing blocks', () => {
+      it('should compare dependency vs dependencies', async () => {
+        const result = await toolHandler.executeTool('compare_hcl_blocks', {
+          block1: 'dependency',
+          block2: 'dependencies'
+        });
+        
+        expect(result.found).toBe(true);
+        expect(result.comparison).toBeDefined();
+        expect(result.comparison.id).toBe('dependency-vs-dependencies');
+        expect(result.comparison.summary).toContain('output');
+      });
+
+      it('should compare using natural language query', async () => {
+        const result = await toolHandler.executeTool('compare_hcl_blocks', {
+          block1: 'inputs vs locals'
+        });
+        
+        expect(result.found).toBe(true);
+        expect(result.comparison.id).toBe('inputs-vs-locals');
+      });
+
+      it('should include block details with syntax', async () => {
+        const result = await toolHandler.executeTool('compare_hcl_blocks', {
+          block1: 'dependency',
+          block2: 'dependencies'
+        });
+        
+        expect(result.comparison.block1.name).toBe('dependency');
+        expect(result.comparison.block1.syntax).toContain('dependency');
+        expect(result.comparison.block1.keyFeatures.length).toBeGreaterThan(0);
+        
+        expect(result.comparison.block2.name).toBe('dependencies');
+        expect(result.comparison.block2.syntax).toContain('dependencies');
+      });
+
+      it('should include key differences', async () => {
+        const result = await toolHandler.executeTool('compare_hcl_blocks', {
+          block1: 'dependency vs dependencies'
+        });
+        
+        expect(result.comparison.keyDifferences).toBeDefined();
+        expect(result.comparison.keyDifferences.length).toBeGreaterThan(0);
+        
+        const diff = result.comparison.keyDifferences[0];
+        expect(diff.aspect).toBeDefined();
+        expect(diff.block1).toBeDefined();
+        expect(diff.block2).toBeDefined();
+      });
+
+      it('should include when-to-use guidance', async () => {
+        const result = await toolHandler.executeTool('compare_hcl_blocks', {
+          block1: 'dependency',
+          block2: 'dependencies'
+        });
+        
+        expect(result.comparison.whenToUse).toBeDefined();
+        expect(result.comparison.whenToUse.useBlock1When.length).toBeGreaterThan(0);
+        expect(result.comparison.whenToUse.useBlock2When.length).toBeGreaterThan(0);
+      });
+
+      it('should include common mistakes', async () => {
+        const result = await toolHandler.executeTool('compare_hcl_blocks', {
+          block1: 'dependency',
+          block2: 'dependencies'
+        });
+        
+        expect(result.comparison.commonMistakes).toBeDefined();
+        expect(result.comparison.commonMistakes.length).toBeGreaterThan(0);
+      });
+
+      it('should include related documentation links', async () => {
+        const result = await toolHandler.executeTool('compare_hcl_blocks', {
+          block1: 'dependency',
+          block2: 'dependencies'
+        });
+        
+        expect(result.comparison.relatedDocs).toBeDefined();
+        expect(result.comparison.relatedDocs.length).toBeGreaterThan(0);
+        expect(result.comparison.relatedDocs[0]).toContain('terragrunt.gruntwork.io');
+      });
+    });
+
+    describe('error handling', () => {
+      it('should return error when no blocks specified', async () => {
+        const result = await toolHandler.executeTool('compare_hcl_blocks', {});
+        
+        expect(result.error).toBeDefined();
+        expect(result.availableComparisons).toBeDefined();
+        expect(result.examples).toBeDefined();
+      });
+
+      it('should return suggestions for unknown block', async () => {
+        const result = await toolHandler.executeTool('compare_hcl_blocks', {
+          block1: 'unknown_block',
+          block2: 'another_unknown'
+        });
+        
+        expect(result.found).toBe(false);
+        expect(result.error).toBeDefined();
+        expect(result.suggestions).toBeDefined();
+      });
+
+      it('should suggest related comparisons for single block', async () => {
+        const result = await toolHandler.executeTool('compare_hcl_blocks', {
+          block1: 'dependency'
+        });
+        
+        expect(result.found).toBe(false);
+        expect(result.suggestions).toBeDefined();
+      });
+    });
+
+    describe('all available comparisons', () => {
+      it('should compare include patterns', async () => {
+        const result = await toolHandler.executeTool('compare_hcl_blocks', {
+          block1: 'include vs multiple includes'
+        });
+        
+        expect(result.found).toBe(true);
+        expect(result.comparison.id).toBe('include-single-vs-multiple');
+      });
+
+      it('should compare generate vs terraform.source', async () => {
+        const result = await toolHandler.executeTool('compare_hcl_blocks', {
+          block1: 'generate',
+          block2: 'terraform.source'
+        });
+        
+        expect(result.found).toBe(true);
+        expect(result.comparison.id).toBe('generate-vs-terraform-source');
+      });
+
+      it('should compare before_hook vs after_hook', async () => {
+        const result = await toolHandler.executeTool('compare_hcl_blocks', {
+          block1: 'before_hook vs after_hook'
+        });
+        
+        expect(result.found).toBe(true);
+        expect(result.comparison.id).toBe('before-hook-vs-after-hook');
+      });
+
+      it('should compare remote_state vs dependency', async () => {
+        const result = await toolHandler.executeTool('compare_hcl_blocks', {
+          block1: 'remote_state',
+          block2: 'dependency'
+        });
+        
+        expect(result.found).toBe(true);
+        expect(result.comparison.id).toBe('remote-state-vs-dependency');
+      });
+    });
+  });
+
+  describe('get_pattern_guidance tool', () => {
+    describe('listing patterns', () => {
+      it('should list all available patterns', async () => {
+        const result = await toolHandler.executeTool('get_pattern_guidance', {
+          listPatterns: true
+        });
+        
+        expect(result.availablePatternTopics).toBeDefined();
+        expect(result.availablePatternTopics.length).toBeGreaterThanOrEqual(3);
+        expect(result.relatedBlockComparisons).toBeDefined();
+        expect(result.usage).toBeDefined();
+      });
+    });
+
+    describe('getting guidance', () => {
+      it('should get guidance for dependency management', async () => {
+        const result = await toolHandler.executeTool('get_pattern_guidance', {
+          scenario: 'managing dependencies'
+        });
+        
+        expect(result.found).toBe(true);
+        expect(result.guidance).toBeDefined();
+        expect(result.guidance.id).toBe('module-dependency-management');
+      });
+
+      it('should get guidance for configuration inheritance', async () => {
+        const result = await toolHandler.executeTool('get_pattern_guidance', {
+          scenario: 'configuration inheritance'
+        });
+        
+        expect(result.found).toBe(true);
+        expect(result.guidance.id).toBe('configuration-inheritance');
+      });
+
+      it('should get guidance for backend state', async () => {
+        const result = await toolHandler.executeTool('get_pattern_guidance', {
+          scenario: 'backend state management'
+        });
+        
+        expect(result.found).toBe(true);
+        expect(result.guidance.id).toBe('backend-state-management');
+      });
+
+      it('should include decision criteria', async () => {
+        const result = await toolHandler.executeTool('get_pattern_guidance', {
+          scenario: 'managing dependencies'
+        });
+        
+        expect(result.guidance.decisionCriteria).toBeDefined();
+        expect(result.guidance.decisionCriteria.length).toBeGreaterThan(0);
+        
+        const criterion = result.guidance.decisionCriteria[0];
+        expect(criterion.criterion).toBeDefined();
+        expect(criterion.recommendation).toBeDefined();
+        expect(criterion.reason).toBeDefined();
+      });
+
+      it('should include patterns with examples', async () => {
+        const result = await toolHandler.executeTool('get_pattern_guidance', {
+          scenario: 'managing dependencies'
+        });
+        
+        expect(result.guidance.patterns).toBeDefined();
+        expect(result.guidance.patterns.length).toBeGreaterThan(0);
+        
+        const pattern = result.guidance.patterns[0];
+        expect(pattern.name).toBeDefined();
+        expect(pattern.description).toBeDefined();
+        expect(pattern.example).toBeDefined();
+        expect(pattern.pros).toBeDefined();
+        expect(pattern.cons).toBeDefined();
+      });
+
+      it('should include related comparisons', async () => {
+        const result = await toolHandler.executeTool('get_pattern_guidance', {
+          scenario: 'managing dependencies'
+        });
+        
+        expect(result.guidance.relatedComparisons).toBeDefined();
+        expect(result.guidance.relatedComparisons.length).toBeGreaterThan(0);
+        expect(result.guidance.relatedComparisons[0]).toContain('dependency');
+      });
+    });
+
+    describe('keyword matching', () => {
+      it('should find by keyword "dependency"', async () => {
+        const result = await toolHandler.executeTool('get_pattern_guidance', {
+          scenario: 'dependency order execution'
+        });
+        
+        expect(result.found).toBe(true);
+        expect(result.guidance.id).toBe('module-dependency-management');
+      });
+
+      it('should find by keyword "include"', async () => {
+        const result = await toolHandler.executeTool('get_pattern_guidance', {
+          scenario: 'include dry parent'
+        });
+        
+        expect(result.found).toBe(true);
+        expect(result.guidance.id).toBe('configuration-inheritance');
+      });
+
+      it('should find by keyword "s3" or "backend"', async () => {
+        const result = await toolHandler.executeTool('get_pattern_guidance', {
+          scenario: 's3 backend storage'
+        });
+        
+        expect(result.found).toBe(true);
+        expect(result.guidance.id).toBe('backend-state-management');
+      });
+    });
+
+    describe('error handling', () => {
+      it('should return error when no scenario specified', async () => {
+        const result = await toolHandler.executeTool('get_pattern_guidance', {});
+        
+        expect(result.error).toBeDefined();
+        expect(result.availablePatternTopics).toBeDefined();
+        expect(result.examples).toBeDefined();
+      });
+
+      it('should return suggestions for unknown scenario', async () => {
+        const result = await toolHandler.executeTool('get_pattern_guidance', {
+          scenario: 'quantum computing in terragrunt'
+        });
+        
+        expect(result.found).toBe(false);
+        expect(result.error).toBeDefined();
+        expect(result.suggestions).toBeDefined();
+      });
+    });
+  });
+
+  describe('Tool Integration', () => {
+    it('should have consistent pattern-comparison references', async () => {
+      // Get a pattern that references comparisons
+      const guidanceResult = await toolHandler.executeTool('get_pattern_guidance', {
+        scenario: 'managing dependencies'
+      });
+      
+      expect(guidanceResult.found).toBe(true);
+      
+      // Verify referenced comparisons exist
+      for (const compRef of guidanceResult.guidance.relatedComparisons) {
+        const compResult = await toolHandler.executeTool('compare_hcl_blocks', {
+          block1: compRef
+        });
+        
+        // Either found or suggestions (comparison name format matches tool input)
+        expect(compResult.found || compResult.suggestions).toBeTruthy();
+      }
+    });
+
+    it('should provide comprehensive dependency coverage', async () => {
+      // Both tools should cover dependency-related topics
+      const comparison = await toolHandler.executeTool('compare_hcl_blocks', {
+        block1: 'dependency vs dependencies'
+      });
+      
+      const guidance = await toolHandler.executeTool('get_pattern_guidance', {
+        scenario: 'managing dependencies'
+      });
+      
+      expect(comparison.found).toBe(true);
+      expect(guidance.found).toBe(true);
+      
+      // Guidance should reference the comparison
+      expect(guidance.guidance.relatedComparisons).toContain('dependency vs dependencies');
+    });
+  });
+});

--- a/test/unit/comparisons.test.ts
+++ b/test/unit/comparisons.test.ts
@@ -1,0 +1,399 @@
+/**
+ * Unit tests for BlockComparisonManager
+ */
+
+import { describe, it, expect, beforeEach } from 'vitest';
+import { BlockComparisonManager } from '../../src/terragrunt/comparisons.js';
+
+describe('BlockComparisonManager', () => {
+  let manager: BlockComparisonManager;
+
+  beforeEach(() => {
+    manager = new BlockComparisonManager();
+  });
+
+  describe('initialization', () => {
+    it('should load all block comparisons on creation', () => {
+      const comparisons = manager.getAvailableComparisons();
+      expect(comparisons.length).toBeGreaterThanOrEqual(5);
+    });
+
+    it('should load all pattern guidance on creation', () => {
+      const patterns = manager.getAvailablePatterns();
+      expect(patterns.length).toBeGreaterThanOrEqual(3);
+    });
+
+    it('should list comparison IDs', () => {
+      const ids = manager.listComparisonIds();
+      expect(ids).toContain('dependency-vs-dependencies');
+      expect(ids).toContain('include-single-vs-multiple');
+      expect(ids).toContain('inputs-vs-locals');
+    });
+
+    it('should list pattern IDs', () => {
+      const ids = manager.listPatternIds();
+      expect(ids).toContain('module-dependency-management');
+      expect(ids).toContain('configuration-inheritance');
+      expect(ids).toContain('backend-state-management');
+    });
+  });
+
+  describe('compareBlocks', () => {
+    describe('with separate block names', () => {
+      it('should find comparison for dependency vs dependencies', () => {
+        const result = manager.compareBlocks('dependency', 'dependencies');
+        
+        expect(result.found).toBe(true);
+        expect(result.comparison).toBeDefined();
+        expect(result.comparison!.id).toBe('dependency-vs-dependencies');
+        expect(result.comparison!.blocks).toEqual(['dependency', 'dependencies']);
+      });
+
+      it('should find comparison regardless of block order', () => {
+        const result1 = manager.compareBlocks('dependency', 'dependencies');
+        const result2 = manager.compareBlocks('dependencies', 'dependency');
+        
+        expect(result1.found).toBe(true);
+        expect(result2.found).toBe(true);
+        expect(result1.comparison!.id).toBe(result2.comparison!.id);
+      });
+
+      it('should find comparison for inputs vs locals', () => {
+        const result = manager.compareBlocks('inputs', 'locals');
+        
+        expect(result.found).toBe(true);
+        expect(result.comparison!.id).toBe('inputs-vs-locals');
+      });
+
+      it('should find comparison for generate vs terraform.source', () => {
+        const result = manager.compareBlocks('generate', 'terraform.source');
+        
+        expect(result.found).toBe(true);
+        expect(result.comparison!.id).toBe('generate-vs-terraform-source');
+      });
+
+      it('should find comparison for before_hook vs after_hook', () => {
+        const result = manager.compareBlocks('before_hook', 'after_hook');
+        
+        expect(result.found).toBe(true);
+        expect(result.comparison!.id).toBe('before-hook-vs-after-hook');
+      });
+    });
+
+    describe('with natural language query', () => {
+      it('should parse "dependency vs dependencies" query', () => {
+        const result = manager.compareBlocks('dependency vs dependencies');
+        
+        expect(result.found).toBe(true);
+        expect(result.comparison!.id).toBe('dependency-vs-dependencies');
+      });
+
+      it('should parse "inputs versus locals" query', () => {
+        const result = manager.compareBlocks('inputs versus locals');
+        
+        expect(result.found).toBe(true);
+        expect(result.comparison!.id).toBe('inputs-vs-locals');
+      });
+
+      it('should parse "generate compared to terraform.source" query', () => {
+        const result = manager.compareBlocks('generate compared to terraform.source');
+        
+        expect(result.found).toBe(true);
+        expect(result.comparison!.id).toBe('generate-vs-terraform-source');
+      });
+
+      it('should parse "before_hook or after_hook" query', () => {
+        const result = manager.compareBlocks('before_hook or after_hook');
+        
+        expect(result.found).toBe(true);
+        expect(result.comparison!.id).toBe('before-hook-vs-after-hook');
+      });
+    });
+
+    describe('fuzzy matching', () => {
+      it('should match with minor typos', () => {
+        // "dependecy" is close to "dependency"
+        const result = manager.compareBlocks('dependecy', 'dependencies');
+        
+        expect(result.found).toBe(true);
+        expect(result.comparison!.id).toBe('dependency-vs-dependencies');
+      });
+
+      it('should match case-insensitively', () => {
+        const result = manager.compareBlocks('DEPENDENCY', 'DEPENDENCIES');
+        
+        expect(result.found).toBe(true);
+        expect(result.comparison!.id).toBe('dependency-vs-dependencies');
+      });
+
+      it('should handle underscores and hyphens', () => {
+        const result = manager.compareBlocks('before-hook', 'after-hook');
+        
+        expect(result.found).toBe(true);
+        expect(result.comparison!.id).toBe('before-hook-vs-after-hook');
+      });
+    });
+
+    describe('error handling', () => {
+      it('should return suggestions for single block query', () => {
+        const result = manager.compareBlocks('dependency');
+        
+        expect(result.found).toBe(false);
+        expect(result.suggestions).toBeDefined();
+        expect(result.suggestions!.length).toBeGreaterThan(0);
+      });
+
+      it('should return error for unknown blocks', () => {
+        const result = manager.compareBlocks('unknown_block', 'another_unknown');
+        
+        expect(result.found).toBe(false);
+        expect(result.error).toBeDefined();
+        expect(result.suggestions).toBeDefined();
+      });
+
+      it('should return error for blocks without comparison', () => {
+        const result = manager.compareBlocks('dependency', 'generate');
+        
+        expect(result.found).toBe(false);
+        expect(result.error).toBeDefined();
+      });
+    });
+
+    describe('comparison content', () => {
+      it('should include all required fields in comparison', () => {
+        const result = manager.compareBlocks('dependency', 'dependencies');
+        
+        const comparison = result.comparison!;
+        expect(comparison.id).toBeDefined();
+        expect(comparison.blocks).toHaveLength(2);
+        expect(comparison.summary).toBeDefined();
+        expect(comparison.block1Details).toBeDefined();
+        expect(comparison.block2Details).toBeDefined();
+        expect(comparison.keyDifferences).toBeDefined();
+        expect(comparison.whenToUse).toBeDefined();
+        expect(comparison.commonMistakes).toBeDefined();
+        expect(comparison.relatedDocs).toBeDefined();
+      });
+
+      it('should have block details with syntax examples', () => {
+        const result = manager.compareBlocks('dependency', 'dependencies');
+        
+        const { block1Details, block2Details } = result.comparison!;
+        
+        expect(block1Details.name).toBe('dependency');
+        expect(block1Details.purpose).toBeDefined();
+        expect(block1Details.syntax).toContain('dependency');
+        expect(block1Details.keyFeatures.length).toBeGreaterThan(0);
+        
+        expect(block2Details.name).toBe('dependencies');
+        expect(block2Details.purpose).toBeDefined();
+        expect(block2Details.syntax).toContain('dependencies');
+        expect(block2Details.keyFeatures.length).toBeGreaterThan(0);
+      });
+
+      it('should have key differences', () => {
+        const result = manager.compareBlocks('dependency', 'dependencies');
+        
+        const { keyDifferences } = result.comparison!;
+        expect(keyDifferences.length).toBeGreaterThan(0);
+        
+        const firstDiff = keyDifferences[0];
+        expect(firstDiff.aspect).toBeDefined();
+        expect(firstDiff.block1).toBeDefined();
+        expect(firstDiff.block2).toBeDefined();
+      });
+
+      it('should have when-to-use guidance', () => {
+        const result = manager.compareBlocks('dependency', 'dependencies');
+        
+        const { whenToUse } = result.comparison!;
+        expect(whenToUse.useBlock1When.length).toBeGreaterThan(0);
+        expect(whenToUse.useBlock2When.length).toBeGreaterThan(0);
+      });
+    });
+  });
+
+  describe('getPatternGuidance', () => {
+    describe('finding patterns', () => {
+      it('should find guidance for "managing dependencies"', () => {
+        const result = manager.getPatternGuidance('managing dependencies');
+        
+        expect(result.found).toBe(true);
+        expect(result.guidance).toBeDefined();
+        expect(result.guidance!.id).toBe('module-dependency-management');
+      });
+
+      it('should find guidance for "configuration inheritance"', () => {
+        const result = manager.getPatternGuidance('configuration inheritance');
+        
+        expect(result.found).toBe(true);
+        expect(result.guidance!.id).toBe('configuration-inheritance');
+      });
+
+      it('should find guidance for "backend state"', () => {
+        const result = manager.getPatternGuidance('backend state');
+        
+        expect(result.found).toBe(true);
+        expect(result.guidance!.id).toBe('backend-state-management');
+      });
+
+      it('should find guidance by keywords', () => {
+        const result = manager.getPatternGuidance('dependency order execution');
+        
+        expect(result.found).toBe(true);
+        expect(result.guidance!.id).toBe('module-dependency-management');
+      });
+
+      it('should find guidance by question-like query', () => {
+        const result = manager.getPatternGuidance('how should I manage dependencies');
+        
+        expect(result.found).toBe(true);
+        expect(result.guidance!.id).toBe('module-dependency-management');
+      });
+    });
+
+    describe('guidance content', () => {
+      it('should include all required fields', () => {
+        const result = manager.getPatternGuidance('managing dependencies');
+        
+        const guidance = result.guidance!;
+        expect(guidance.id).toBeDefined();
+        expect(guidance.scenario).toBeDefined();
+        expect(guidance.question).toBeDefined();
+        expect(guidance.keywords).toBeDefined();
+        expect(guidance.decisionCriteria).toBeDefined();
+        expect(guidance.patterns).toBeDefined();
+        expect(guidance.relatedComparisons).toBeDefined();
+      });
+
+      it('should have decision criteria', () => {
+        const result = manager.getPatternGuidance('managing dependencies');
+        
+        const { decisionCriteria } = result.guidance!;
+        expect(decisionCriteria.length).toBeGreaterThan(0);
+        
+        const firstCriterion = decisionCriteria[0];
+        expect(firstCriterion.criterion).toBeDefined();
+        expect(firstCriterion.recommendation).toBeDefined();
+        expect(firstCriterion.reason).toBeDefined();
+      });
+
+      it('should have patterns with pros and cons', () => {
+        const result = manager.getPatternGuidance('managing dependencies');
+        
+        const { patterns } = result.guidance!;
+        expect(patterns.length).toBeGreaterThan(0);
+        
+        const firstPattern = patterns[0];
+        expect(firstPattern.name).toBeDefined();
+        expect(firstPattern.description).toBeDefined();
+        expect(firstPattern.example).toBeDefined();
+        expect(firstPattern.pros.length).toBeGreaterThan(0);
+        expect(firstPattern.cons.length).toBeGreaterThan(0);
+      });
+
+      it('should reference related comparisons', () => {
+        const result = manager.getPatternGuidance('managing dependencies');
+        
+        const { relatedComparisons } = result.guidance!;
+        expect(relatedComparisons).toContain('dependency-vs-dependencies');
+      });
+    });
+
+    describe('error handling', () => {
+      it('should return suggestions for unknown scenario', () => {
+        const result = manager.getPatternGuidance('quantum computing');
+        
+        expect(result.found).toBe(false);
+        expect(result.suggestions).toBeDefined();
+        expect(result.suggestions!.length).toBeGreaterThan(0);
+      });
+
+      it('should return error message', () => {
+        const result = manager.getPatternGuidance('unknown topic');
+        
+        expect(result.found).toBe(false);
+        expect(result.error).toBeDefined();
+      });
+    });
+  });
+
+  describe('searchComparisons', () => {
+    it('should find comparisons by block name', () => {
+      const results = manager.searchComparisons('dependency');
+      
+      expect(results.length).toBeGreaterThan(0);
+      expect(results[0].item.blocks.some(b => b.includes('dependency'))).toBe(true);
+    });
+
+    it('should find comparisons by keyword in summary', () => {
+      const results = manager.searchComparisons('outputs');
+      
+      expect(results.length).toBeGreaterThan(0);
+    });
+
+    it('should return empty for unrelated query', () => {
+      const results = manager.searchComparisons('quantum entanglement');
+      
+      expect(results.length).toBe(0);
+    });
+
+    it('should sort results by relevance score', () => {
+      const results = manager.searchComparisons('dependency');
+      
+      if (results.length > 1) {
+        expect(results[0].score).toBeGreaterThanOrEqual(results[1].score);
+      }
+    });
+  });
+
+  describe('getComparisonById', () => {
+    it('should return comparison for valid ID', () => {
+      const comparison = manager.getComparisonById('dependency-vs-dependencies');
+      
+      expect(comparison).toBeDefined();
+      expect(comparison!.id).toBe('dependency-vs-dependencies');
+    });
+
+    it('should return undefined for invalid ID', () => {
+      const comparison = manager.getComparisonById('invalid-id');
+      
+      expect(comparison).toBeUndefined();
+    });
+  });
+
+  describe('getPatternById', () => {
+    it('should return pattern for valid ID', () => {
+      const pattern = manager.getPatternById('module-dependency-management');
+      
+      expect(pattern).toBeDefined();
+      expect(pattern!.id).toBe('module-dependency-management');
+    });
+
+    it('should return undefined for invalid ID', () => {
+      const pattern = manager.getPatternById('invalid-id');
+      
+      expect(pattern).toBeUndefined();
+    });
+  });
+
+  describe('available comparisons', () => {
+    it('should return human-readable comparison names', () => {
+      const comparisons = manager.getAvailableComparisons();
+      
+      expect(comparisons).toContain('dependency vs dependencies');
+      expect(comparisons).toContain('include vs multiple includes');
+      expect(comparisons).toContain('inputs vs locals');
+    });
+  });
+
+  describe('available patterns', () => {
+    it('should return human-readable pattern scenarios', () => {
+      const patterns = manager.getAvailablePatterns();
+      
+      expect(patterns.some(p => p.includes('dependencies'))).toBe(true);
+      expect(patterns.some(p => p.includes('inheritance'))).toBe(true);
+      expect(patterns.some(p => p.includes('state'))).toBe(true);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Implements Issue #106 - Enhancement: Provide Block Comparison and Pattern Guidance

This PR adds two new tools to help users understand differences between similar HCL blocks and choose appropriate configuration patterns.

## New Tools

### compare_hcl_blocks
Compare two similar HCL blocks and explain their differences, use cases, and when to use each.

**Features:**
- 6 curated block comparisons with syntax examples
- Natural language query parsing (e.g., 'dependency vs dependencies')
- Fuzzy matching with Levenshtein distance for typo tolerance
- Key differences, when-to-use guidance, and common mistakes

**Available Comparisons:**
| Comparison | Summary |
|------------|---------|
| `dependency` vs `dependencies` | Single dependency with output access vs. bulk ordering |
| `include` vs `multiple includes` | Single parent inheritance vs. composable config |
| `inputs` vs `locals` | Values passed to Terraform vs. internal values |
| `generate` vs `terraform.source` | Creating .tf files vs. specifying module source |
| `before_hook` vs `after_hook` | Commands before vs. after Terraform |
| `remote_state` vs `dependency` | State storage config vs. output reading |

### get_pattern_guidance
Get guidance on choosing between Terragrunt configuration patterns for common scenarios.

**Features:**
- Decision criteria with recommendations and reasons
- Multiple patterns with pros/cons and code examples
- Related block comparisons for deeper exploration

**Available Topics:**
- Module dependency management
- Configuration inheritance (DRY patterns)
- Backend state management

## Implementation Details

- New `BlockComparisonManager` class in `src/terragrunt/comparisons.ts`
- Type definitions in `src/types/comparisons.ts`
- 44 unit tests for the manager
- 31 integration tests for the tools
- Documentation in `docs/Available-Tools.md`

## Test Results
All 1697 tests pass (1622 existing + 75 new)

Closes #106