### PR TITLE
feat(schema): add complete AWS S3 backend schema

### DIFF
--- a/schemas/backends/aws-s3-complete.json
+++ b/schemas/backends/aws-s3-complete.json
@@ -27,7 +27,7 @@
     {
       "name": "region",
       "type": "string",
-      "required": true,
+      "required": false,
       "description": "AWS Region of the S3 Bucket and DynamoDB Table (if used). Can also be sourced from the AWS_DEFAULT_REGION and AWS_REGION environment variables.",
       "example": "us-east-1",
       "validValues": [
@@ -201,13 +201,13 @@
       "name": "assume_role_policy",
       "type": "string",
       "required": false,
-      "description": "IAM Policy JSON describing further restricting permissions for the IAM Role being assumed. This is a session policy that limits the effective permissions."
+      "description": "IAM Policy JSON that further restricts permissions for the IAM Role being assumed. This is a session policy that limits the effective permissions."
     },
     {
       "name": "assume_role_policy_arns",
       "type": "list",
       "required": false,
-      "description": "Set of Amazon Resource Names (ARNs) of IAM Policies describing further restricting permissions for the IAM Role being assumed."
+      "description": "Set of Amazon Resource Names (ARNs) of IAM Policies that further restrict permissions for the IAM Role being assumed."
     },
     {
       "name": "assume_role_session_name",
@@ -255,7 +255,7 @@
       "name": "assume_role_with_web_identity_policy",
       "type": "string",
       "required": false,
-      "description": "IAM Policy JSON describing further restricting permissions for the IAM Role being assumed via Web Identity."
+      "description": "IAM Policy JSON that further restricts permissions for the IAM Role being assumed via Web Identity."
     },
     {
       "name": "assume_role_with_web_identity_policy_arns",

--- a/test/unit/backend-schema.test.ts
+++ b/test/unit/backend-schema.test.ts
@@ -890,12 +890,11 @@ describe('Real AWS S3 Complete Schema File', () => {
     const schema = await loadBackendSchema(schemaPath);
     
     const required = getRequiredAttributes(schema);
-    expect(required).toHaveLength(3);
+    expect(required).toHaveLength(2);
     
     const requiredNames = required.map(a => a.name);
     expect(requiredNames).toContain('bucket');
     expect(requiredNames).toContain('key');
-    expect(requiredNames).toContain('region');
   });
 
   it('should have sensitive attributes for secrets', async () => {


### PR DESCRIPTION
## Summary

Implements #140 - Create AWS S3 Complete Backend Schema

This schema provides comprehensive coverage of all Terraform S3 backend attributes (~65 total), significantly expanding beyond the basic schema's ~25 attributes.

## Part of Epic #138

This is part of the Backend Schema Library epic, following the same pattern established by the Azure Blob schema (#141, PR #155).

## Key Additions

### Core S3 Settings
- `bucket`, `key`, `region` (required)
- `workspace_key_prefix`, `encrypt`, `kms_key_id`, `sse_customer_key`

### State Locking
- `use_lockfile` - New S3-native locking (Terraform 1.10+)
- `dynamodb_table`, `dynamodb_endpoint` - Deprecated DynamoDB-based locking

### Authentication Methods
- Static credentials: `access_key`, `secret_key`, `token`
- Profile-based: `profile`, `shared_credentials_files`, `shared_config_files`
- Assume Role (IAM): 9 attributes with `assume_role_` prefix
- Web Identity (OIDC): 7 attributes with `assume_role_with_web_identity_` prefix

### Custom Endpoints
- 5 service endpoints with `endpoints_` prefix (dynamodb, iam, s3, sso, sts)

### Network/Proxy
- `http_proxy`, `https_proxy`, `no_proxy`, `insecure`

### Retry Configuration
- `retry_mode`, `max_retries`

### Skip Validation Flags
- `skip_credentials_validation`, `skip_metadata_api_check`, `skip_region_validation`, `skip_requesting_account_id`, `skip_s3_checksum`

### Legacy Deprecated Attributes
- Root-level `assume_role_*` attributes (pre-Terraform 1.6 style)

## Schema Features

- **Conflict relationships**: e.g., `access_key` conflicts with `profile`
- **ARN patterns**: For IAM role attributes
- **AWS region validation**: Full list of valid regions
- **Sensitive field marking**: For secrets and credentials
- **Detailed descriptions**: From official Terraform documentation

## Testing

Added 17 unit tests covering:
- Required attributes validation
- Sensitive fields identification
- S3-native and DynamoDB locking attributes
- Conflict relationships
- ARN pattern validation
- Region value validation
- Assume role attributes
- Web identity attributes
- Endpoint attributes
- Proxy/network attributes
- Skip validation flags
- Retry configuration
- Encryption attributes with conflicts

All 85 backend schema tests pass.

## Checklist

- [x] Schema follows the established format from `schemas/backends/s3.json`
- [x] All Terraform S3 backend attributes covered (~65 attributes)
- [x] Proper conflict relationships defined
- [x] Sensitive fields marked appropriately
- [x] Deprecated attributes marked with deprecation info
- [x] Unit tests added and passing
- [x] Documentation references Terraform official docs

Closes #140