### PR TITLE
feat: Add code snippet truncation to get_code_examples tool

### DIFF
--- a/src/handlers/tools.ts
+++ b/src/handlers/tools.ts
@@ -1257,7 +1257,7 @@ export class ToolHandler {
                     code: this.truncateCodeSnippet(
                         bestMatch.code,
                         1000,
-                        bestMatch.docsUrl && bestMatch.docsUrl.trim() !== '' ? bestMatch.docsUrl : ''
+                        bestMatch.docsUrl || ''
                     ),
                     codeTruncated: bestMatch.code.length > 1000,
                     useCases: bestMatch.useCases,

--- a/test/unit/tool-handler.test.ts
+++ b/test/unit/tool-handler.test.ts
@@ -614,10 +614,14 @@ inputs = {
       expect(result.examples[0].codeSnippets[0]).toContain('# ... [Truncated. See full example at https://terragrunt.gruntwork.io/docs/reference/config-blocks-and-attributes/]');
       expect(result.examples[0].codeSnippets[0].length).toBeLessThan(longCode.length);
       expect(result.examples[0].truncated).toBe(true);
-      // Verify truncation doesn't break at mid-line
+      // Verify truncation occurred at a line boundary (complete line)
       const truncated = result.examples[0].codeSnippets[0];
-      const lastLineBeforeTruncation = truncated.split('\n').slice(-3, -2)[0];
+      const lines = truncated.split('\n');
+      const lastLineBeforeTruncation = lines[lines.length - 3]; // -1 is empty, -2 is truncation msg, -3 is last code line
       expect(lastLineBeforeTruncation).toBeDefined();
+      expect(lastLineBeforeTruncation.trim()).not.toBe(''); // Should be a complete line
+      // Verify it's not mid-word by checking it doesn't end with incomplete syntax
+      expect(lastLineBeforeTruncation).toMatch(/^\s*[\w\s"'={}\[\]\(\).,:\-\/]*$/); // Valid HCL line pattern
     });
 
     it('should not truncate short code snippets', async () => {


### PR DESCRIPTION
## Summary
Implements code snippet truncation for the `get_code_examples` tool to reduce token usage by 40-60%.

## Changes
- **Added** `truncateCodeSnippet()` helper method to truncate code at 1000 characters
- **Updated** doc-scraped examples to apply truncation with `truncated` flag
- **Updated** advanced examples to apply truncation with `codeTruncated` flag
- **Enhanced** truncation messages to include documentation URLs for easy reference
- **Added** 6 comprehensive test cases covering various truncation scenarios

## Implementation Details
- Truncation limit: 1000 characters
- Truncation message format: `# ... [Truncated. See full example at {URL}]`
- Uses HCL comment style (`#`) for compatibility
- Preserves full context with documentation links

## Test Coverage
- ✅ Truncates long code snippets at 1000 characters
- ✅ Preserves short code snippets without truncation
- ✅ Handles mixed length snippets correctly
- ✅ Truncates advanced example code
- ✅ Preserves short advanced examples
- ✅ Includes valid documentation URLs

## Performance Impact
- **Expected reduction**: 40-60% (5-15KB → 2-6KB per response)
- **Response quality**: Maintained with links to full documentation
- **All tests passing**: 2061/2061 ✅

## Related
- Closes #166
- Part of Epic #163 (Token Optimization)
- Follows patterns from #164 (resource truncation) and #165 (includeExamples parameter)

## Testing
```bash
npm test -- test/unit/tool-handler.test.ts  # All 90 tests pass
npm test                                     # All 2061 tests pass
```