### PR TITLE
feat(docs): add fetchFromLlmsTxt() method

### DIFF
--- a/src/terragrunt/docs.ts
+++ b/src/terragrunt/docs.ts
@@ -296,6 +296,11 @@ export class TerragruntDocsManager {
         return await operation();
       } catch (error) {
         lastError = error instanceof Error ? error : new Error(String(error));
+
+        // Non-retryable errors should propagate immediately
+        if (lastError.name === 'NonRetryableError') {
+          throw lastError;
+        }
         
         if (attempt < this.retryConfig.maxRetries) {
           console.warn(`${context} failed (attempt ${attempt + 1}/${this.retryConfig.maxRetries + 1}): ${lastError.message}`);
@@ -1260,17 +1265,39 @@ export class TerragruntDocsManager {
   /**
    * Fetch and parse the llms.txt endpoint into TerragruntDoc[].
    * Uses TERRAGRUNT_LLMS_SOURCE env var to override the default URL.
+   * The env var accepts an absolute URL (with scheme) or a path/filename
+   * relative to the base URL (e.g., "llms-full.txt" or "/llms-full.txt").
    * Never throws — returns empty array and logs on failure.
    */
   async fetchFromLlmsTxt(): Promise<TerragruntDoc[]> {
     const defaultUrl = `${this.baseUrl}/llms-small.txt`;
-    const url = process.env.TERRAGRUNT_LLMS_SOURCE || defaultUrl;
+    const source = process.env.TERRAGRUNT_LLMS_SOURCE;
+
+    let url: string;
+    if (!source) {
+      url = defaultUrl;
+    } else if (/^[a-zA-Z][a-zA-Z0-9+.-]*:/.test(source)) {
+      // Absolute URL (has a scheme) — use as-is
+      url = source;
+    } else {
+      // Relative path or filename — resolve against baseUrl
+      const normalizedPath = source.startsWith('/') ? source : `/${source}`;
+      url = `${this.baseUrl}${normalizedPath}`;
+    }
 
     try {
       const markdown = await this.retryWithBackoff(async () => {
         const response = await fetch(url);
         if (!response.ok) {
-          throw new Error(`HTTP ${response.status} ${response.statusText}`);
+          const status = response.status;
+          const message = `HTTP ${status} ${response.statusText}`;
+          // Don't retry on client errors (4xx) except 408 (timeout) and 429 (rate limit)
+          if (status >= 400 && status < 500 && status !== 408 && status !== 429) {
+            const err = new Error(message);
+            err.name = 'NonRetryableError';
+            throw err;
+          }
+          throw new Error(message);
         }
         return await response.text();
       }, `Fetching llms.txt from ${url}`);

--- a/test/unit/docs-manager.test.ts
+++ b/test/unit/docs-manager.test.ts
@@ -951,6 +951,7 @@ describe('TerragruntDocsManager', () => {
 
   describe('fetchFromLlmsTxt', () => {
     let manager: TerragruntDocsManager;
+    let mockFetch: ReturnType<typeof vi.fn>;
     const sampleMarkdown = [
       '# Install',
       '',
@@ -961,10 +962,31 @@ describe('TerragruntDocsManager', () => {
       'Quick start guide.',
     ].join('\n');
 
-    beforeEach(() => {
+    /** Helper to create a mock Response-like object */
+    function mockResponse(opts: { ok: boolean; status?: number; statusText?: string; body?: string }) {
+      return {
+        ok: opts.ok,
+        status: opts.status ?? (opts.ok ? 200 : 500),
+        statusText: opts.statusText ?? (opts.ok ? 'OK' : 'Internal Server Error'),
+        text: () => Promise.resolve(opts.body ?? ''),
+      };
+    }
+
+    beforeEach(async () => {
       manager = new TerragruntDocsManager();
+      // Speed up retries for all tests in this suite
+      (manager as any).retryConfig = {
+        maxRetries: 3,
+        initialDelayMs: 1,
+        maxDelayMs: 5,
+        backoffMultiplier: 2,
+      };
       vi.clearAllMocks();
       delete process.env.TERRAGRUNT_LLMS_SOURCE;
+
+      // Obtain a typed reference to the mocked fetch
+      const fetchModule = await import('node-fetch');
+      mockFetch = fetchModule.default as unknown as ReturnType<typeof vi.fn>;
     });
 
     afterAll(() => {
@@ -972,11 +994,7 @@ describe('TerragruntDocsManager', () => {
     });
 
     it('should fetch and parse llms.txt into TerragruntDoc[]', async () => {
-      const fetchMock = await import('node-fetch');
-      (fetchMock.default as unknown as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
-        ok: true,
-        text: () => Promise.resolve(sampleMarkdown),
-      });
+      mockFetch.mockResolvedValueOnce(mockResponse({ ok: true, body: sampleMarkdown }));
 
       const docs = await manager.fetchFromLlmsTxt();
 
@@ -986,37 +1004,43 @@ describe('TerragruntDocsManager', () => {
       expect(docs[1].title).toBe('Quick Start');
       expect(docs[1].section).toBe('getting-started');
 
-      expect(fetchMock.default).toHaveBeenCalledWith('https://terragrunt.gruntwork.io/llms-small.txt');
+      expect(mockFetch).toHaveBeenCalledWith('https://terragrunt.gruntwork.io/llms-small.txt');
     });
 
-    it('should use TERRAGRUNT_LLMS_SOURCE env var to override URL', async () => {
+    it('should use TERRAGRUNT_LLMS_SOURCE env var with absolute URL', async () => {
       process.env.TERRAGRUNT_LLMS_SOURCE = 'https://example.com/llms-full.txt';
 
-      const fetchMock = await import('node-fetch');
-      (fetchMock.default as unknown as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
-        ok: true,
-        text: () => Promise.resolve(sampleMarkdown),
-      });
+      mockFetch.mockResolvedValueOnce(mockResponse({ ok: true, body: sampleMarkdown }));
 
       const docs = await manager.fetchFromLlmsTxt();
 
       expect(docs).toHaveLength(2);
-      expect(fetchMock.default).toHaveBeenCalledWith('https://example.com/llms-full.txt');
+      expect(mockFetch).toHaveBeenCalledWith('https://example.com/llms-full.txt');
+    });
+
+    it('should resolve TERRAGRUNT_LLMS_SOURCE filename against baseUrl', async () => {
+      process.env.TERRAGRUNT_LLMS_SOURCE = 'llms-full.txt';
+
+      mockFetch.mockResolvedValueOnce(mockResponse({ ok: true, body: sampleMarkdown }));
+
+      const docs = await manager.fetchFromLlmsTxt();
+
+      expect(docs).toHaveLength(2);
+      expect(mockFetch).toHaveBeenCalledWith('https://terragrunt.gruntwork.io/llms-full.txt');
+    });
+
+    it('should resolve TERRAGRUNT_LLMS_SOURCE path with leading slash', async () => {
+      process.env.TERRAGRUNT_LLMS_SOURCE = '/custom/llms.txt';
+
+      mockFetch.mockResolvedValueOnce(mockResponse({ ok: true, body: sampleMarkdown }));
+
+      await manager.fetchFromLlmsTxt();
+
+      expect(mockFetch).toHaveBeenCalledWith('https://terragrunt.gruntwork.io/custom/llms.txt');
     });
 
     it('should return empty array on total fetch failure without throwing', async () => {
-      // Speed up retries for testing
-      (manager as any).retryConfig = {
-        maxRetries: 3,
-        initialDelayMs: 1,
-        maxDelayMs: 5,
-        backoffMultiplier: 2,
-      };
-
-      const fetchMock = await import('node-fetch');
-      (fetchMock.default as unknown as ReturnType<typeof vi.fn>).mockRejectedValue(
-        new Error('Network error')
-      );
+      mockFetch.mockRejectedValue(new Error('Network error'));
 
       const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
       const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
@@ -1031,41 +1055,54 @@ describe('TerragruntDocsManager', () => {
       logSpy.mockRestore();
     });
 
-    it('should return empty array on HTTP error without throwing', async () => {
-      // Speed up retries for testing
-      (manager as any).retryConfig = {
-        maxRetries: 3,
-        initialDelayMs: 1,
-        maxDelayMs: 5,
-        backoffMultiplier: 2,
-      };
-
-      const fetchMock = await import('node-fetch');
-      (fetchMock.default as unknown as ReturnType<typeof vi.fn>).mockResolvedValue({
-        ok: false,
-        status: 404,
-        statusText: 'Not Found',
-      });
+    it('should not retry on 4xx HTTP errors (non-retryable)', async () => {
+      mockFetch.mockResolvedValue(mockResponse({ ok: false, status: 404, statusText: 'Not Found' }));
 
       const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+      const docs = await manager.fetchFromLlmsTxt();
+
+      expect(docs).toEqual([]);
+      // Should have been called only once — no retries for 404
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+      expect(consoleSpy).toHaveBeenCalled();
+      consoleSpy.mockRestore();
+    });
+
+    it('should retry on 5xx HTTP errors', async () => {
+      mockFetch
+        .mockResolvedValueOnce(mockResponse({ ok: false, status: 503, statusText: 'Service Unavailable' }))
+        .mockResolvedValueOnce(mockResponse({ ok: true, body: sampleMarkdown }));
+
       const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
       const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
 
       const docs = await manager.fetchFromLlmsTxt();
 
-      expect(docs).toEqual([]);
-      expect(consoleSpy).toHaveBeenCalled();
-      consoleSpy.mockRestore();
+      expect(docs).toHaveLength(2);
+      expect(mockFetch).toHaveBeenCalledTimes(2);
+      warnSpy.mockRestore();
+      logSpy.mockRestore();
+    });
+
+    it('should retry on 429 Too Many Requests', async () => {
+      mockFetch
+        .mockResolvedValueOnce(mockResponse({ ok: false, status: 429, statusText: 'Too Many Requests' }))
+        .mockResolvedValueOnce(mockResponse({ ok: true, body: sampleMarkdown }));
+
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+      const docs = await manager.fetchFromLlmsTxt();
+
+      expect(docs).toHaveLength(2);
+      expect(mockFetch).toHaveBeenCalledTimes(2);
       warnSpy.mockRestore();
       logSpy.mockRestore();
     });
 
     it('should return empty array when response body is empty', async () => {
-      const fetchMock = await import('node-fetch');
-      (fetchMock.default as unknown as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
-        ok: true,
-        text: () => Promise.resolve(''),
-      });
+      mockFetch.mockResolvedValueOnce(mockResponse({ ok: true, body: '' }));
 
       const docs = await manager.fetchFromLlmsTxt();
 
@@ -1073,34 +1110,19 @@ describe('TerragruntDocsManager', () => {
     });
 
     it('should retry on transient failure then succeed', async () => {
-      const fetchMock = await import('node-fetch');
-      const mockFn = fetchMock.default as unknown as ReturnType<typeof vi.fn>;
-
       // Fail twice, then succeed
-      mockFn
+      mockFetch
         .mockRejectedValueOnce(new Error('Temporary failure'))
         .mockRejectedValueOnce(new Error('Temporary failure'))
-        .mockResolvedValueOnce({
-          ok: true,
-          text: () => Promise.resolve(sampleMarkdown),
-        });
+        .mockResolvedValueOnce(mockResponse({ ok: true, body: sampleMarkdown }));
 
-      // Suppress retry warnings
       const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
       const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
-
-      // Speed up retries for testing
-      (manager as any).retryConfig = {
-        maxRetries: 3,
-        initialDelayMs: 1,
-        maxDelayMs: 5,
-        backoffMultiplier: 2,
-      };
 
       const docs = await manager.fetchFromLlmsTxt();
 
       expect(docs).toHaveLength(2);
-      expect(mockFn).toHaveBeenCalledTimes(3);
+      expect(mockFetch).toHaveBeenCalledTimes(3);
 
       warnSpy.mockRestore();
       logSpy.mockRestore();


### PR DESCRIPTION
## Summary

Add `fetchFromLlmsTxt()` to `TerragruntDocsManager` that fetches and parses the llms.txt endpoint into `TerragruntDoc[]`.

### Changes

- Fetches from `https://terragrunt.gruntwork.io/llms-small.txt` by default
- Supports `TERRAGRUNT_LLMS_SOURCE` env var to override source URL (e.g., to `llms-full.txt`)
- Uses existing `retryWithBackoff()` for resilience
- Calls `parseLlmsMarkdown()` to produce `TerragruntDoc[]`
- Never throws — returns empty array + logs error on failure

### Tests

6 unit tests added covering:
- Happy path fetch and parse
- Env var URL override
- Retry on transient failure then succeed
- Total fetch failure returns `[]`
- HTTP error returns `[]`
- Empty response body returns `[]`

Closes #223